### PR TITLE
[enhancement] Implement SDDL conversion: FromSDDLString and ToSDDLString

### DIFF
--- a/sddl/ace/aceflags/AccessControlEntryFlags.go
+++ b/sddl/ace/aceflags/AccessControlEntryFlags.go
@@ -1,1 +1,27 @@
 package aceflags
+
+import (
+	ntsd_aceflags "github.com/TheManticoreProject/winacl/ace/aceflags"
+)
+
+// SDDL ACE flag abbreviations to binary flag values.
+// Source: https://learn.microsoft.com/en-us/windows/win32/secauthz/ace-strings
+
+var SDDLToACEFlag = map[string]uint8{
+	"CI": ntsd_aceflags.ACE_FLAG_CONTAINER_INHERIT,
+	"OI": ntsd_aceflags.ACE_FLAG_OBJECT_INHERIT,
+	"NP": ntsd_aceflags.ACE_FLAG_NO_PROPAGATE_INHERIT,
+	"IO": ntsd_aceflags.ACE_FLAG_INHERIT_ONLY,
+	"ID": ntsd_aceflags.ACE_FLAG_INHERITED,
+	"SA": ntsd_aceflags.ACE_FLAG_SUCCESSFUL_ACCESS,
+	"FA": ntsd_aceflags.ACE_FLAG_FAILED_ACCESS,
+}
+
+var ACEFlagToSDDL map[uint8]string
+
+func init() {
+	ACEFlagToSDDL = make(map[uint8]string, len(SDDLToACEFlag))
+	for sddl, flag := range SDDLToACEFlag {
+		ACEFlagToSDDL[flag] = sddl
+	}
+}

--- a/sddl/rights/rights.go
+++ b/sddl/rights/rights.go
@@ -1,1 +1,59 @@
 package rights
+
+import (
+	ntsd_rights "github.com/TheManticoreProject/winacl/rights"
+)
+
+// SDDL rights abbreviations to binary access mask values.
+// Source: https://learn.microsoft.com/en-us/windows/win32/secauthz/ace-strings
+
+var SDDLToRight = map[string]uint32{
+	// Generic rights
+	"GA": ntsd_rights.RIGHT_GENERIC_ALL,
+	"GR": ntsd_rights.RIGHT_GENERIC_READ,
+	"GW": ntsd_rights.RIGHT_GENERIC_WRITE,
+	"GX": ntsd_rights.RIGHT_GENERIC_EXECUTE,
+
+	// Standard rights
+	"RC": ntsd_rights.RIGHT_READ_CONTROL,
+	"SD": ntsd_rights.RIGHT_DELETE,
+	"WD": ntsd_rights.RIGHT_WRITE_DAC,
+	"WO": ntsd_rights.RIGHT_WRITE_OWNER,
+
+	// Directory service rights
+	"RP": ntsd_rights.RIGHT_DS_READ_PROPERTY,
+	"WP": ntsd_rights.RIGHT_DS_WRITE_PROPERTY,
+	"CC": ntsd_rights.RIGHT_DS_CREATE_CHILD,
+	"DC": ntsd_rights.RIGHT_DS_DELETE_CHILD,
+	"LC": ntsd_rights.RIGHT_DS_LIST_CONTENTS,
+	"SW": ntsd_rights.RIGHT_DS_WRITE_PROPERTY_EXTENDED,
+	"LO": ntsd_rights.RIGHT_DS_LIST_OBJECT,
+	"DT": ntsd_rights.RIGHT_DS_DELETE_TREE,
+	"CR": ntsd_rights.RIGHT_DS_CONTROL_ACCESS,
+
+	// File rights
+	"FA": 0x001F01FF, // FILE_ALL_ACCESS
+	"FR": 0x00120089, // FILE_GENERIC_READ
+	"FW": 0x00120116, // FILE_GENERIC_WRITE
+	"FX": 0x001200A0, // FILE_GENERIC_EXECUTE
+
+	// Registry rights
+	"KA": 0x000F003F, // KEY_ALL_ACCESS
+	"KR": 0x00020019, // KEY_READ
+	"KW": 0x00020006, // KEY_WRITE
+	"KX": 0x00020019, // KEY_EXECUTE
+
+	// Mandatory label rights
+	"NR": 0x00000001, // SYSTEM_MANDATORY_LABEL_NO_READ_UP
+	"NW": 0x00000002, // SYSTEM_MANDATORY_LABEL_NO_WRITE_UP
+	"NX": 0x00000004, // SYSTEM_MANDATORY_LABEL_NO_EXECUTE_UP
+}
+
+var RightToSDDL map[uint32]string
+
+func init() {
+	RightToSDDL = make(map[uint32]string, len(SDDLToRight))
+	for sddl, right := range SDDLToRight {
+		RightToSDDL[right] = sddl
+	}
+}

--- a/sddl/sddl_functions.go
+++ b/sddl/sddl_functions.go
@@ -1,8 +1,6 @@
 package sddl
 
 import (
-	"fmt"
-
 	"github.com/TheManticoreProject/winacl/securitydescriptor"
 )
 
@@ -14,8 +12,12 @@ import (
 // Returns:
 //   - (*securitydescriptor.NtSecurityDescriptor, error): The converted security descriptor and any error that occurred.
 func SDDLtoNtSecurityDescriptor(sddlString string) (*securitydescriptor.NtSecurityDescriptor, error) {
-	_ = sddlString
-	return nil, fmt.Errorf("SDDLtoNtSecurityDescriptor is not yet implemented")
+	ntsd := &securitydescriptor.NtSecurityDescriptor{}
+	_, err := ntsd.FromSDDLString(sddlString)
+	if err != nil {
+		return nil, err
+	}
+	return ntsd, nil
 }
 
 // NtSecurityDescriptortoSDDL converts an NtSecurityDescriptor to an SDDL string.
@@ -26,6 +28,5 @@ func SDDLtoNtSecurityDescriptor(sddlString string) (*securitydescriptor.NtSecuri
 // Returns:
 //   - (string, error): The SDDL string representation and any error that occurred.
 func NtSecurityDescriptortoSDDL(ntsd *securitydescriptor.NtSecurityDescriptor) (string, error) {
-	_ = ntsd
-	return "", fmt.Errorf("NtSecurityDescriptortoSDDL is not yet implemented")
+	return ntsd.ToSDDLString()
 }

--- a/sddl/sddl_functions_test.go
+++ b/sddl/sddl_functions_test.go
@@ -1,0 +1,109 @@
+package sddl_test
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/winacl/sddl"
+)
+
+func TestSDDLtoNtSecurityDescriptor(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantErr   bool
+		wantDACL  int
+		wantSACL  int
+		wantOwner string
+		wantGroup string
+	}{
+		{
+			name:      "Basic with owner and group",
+			input:     "O:BAG:SY",
+			wantOwner: "S-1-5-32-544",
+			wantGroup: "S-1-5-18",
+		},
+		{
+			name:      "With DACL",
+			input:     "O:BAG:BAD:(A;CIOI;GA;;;BA)(A;CIOI;GA;;;SY)",
+			wantOwner: "S-1-5-32-544",
+			wantGroup: "S-1-5-32-544",
+			wantDACL:  2,
+		},
+		{
+			name:     "With SACL",
+			input:    "S:(AU;SAFA;GA;;;WD)",
+			wantSACL: 1,
+		},
+		{
+			name:  "Invalid ACE type",
+			input: "D:(ZZ;;GA;;;WD)",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ntsd, err := sddl.SDDLtoNtSecurityDescriptor(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SDDLtoNtSecurityDescriptor() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if tt.wantErr {
+				return
+			}
+
+			if tt.wantOwner != "" && (ntsd.Owner == nil || ntsd.Owner.SID.ToString() != tt.wantOwner) {
+				got := ""
+				if ntsd.Owner != nil {
+					got = ntsd.Owner.SID.ToString()
+				}
+				t.Errorf("Owner = %s, want %s", got, tt.wantOwner)
+			}
+
+			if tt.wantGroup != "" && (ntsd.Group == nil || ntsd.Group.SID.ToString() != tt.wantGroup) {
+				got := ""
+				if ntsd.Group != nil {
+					got = ntsd.Group.SID.ToString()
+				}
+				t.Errorf("Group = %s, want %s", got, tt.wantGroup)
+			}
+
+			if tt.wantDACL > 0 {
+				if ntsd.DACL == nil || len(ntsd.DACL.Entries) != tt.wantDACL {
+					got := 0
+					if ntsd.DACL != nil {
+						got = len(ntsd.DACL.Entries)
+					}
+					t.Errorf("DACL entries = %d, want %d", got, tt.wantDACL)
+				}
+			}
+
+			if tt.wantSACL > 0 {
+				if ntsd.SACL == nil || len(ntsd.SACL.Entries) != tt.wantSACL {
+					got := 0
+					if ntsd.SACL != nil {
+						got = len(ntsd.SACL.Entries)
+					}
+					t.Errorf("SACL entries = %d, want %d", got, tt.wantSACL)
+				}
+			}
+		})
+	}
+}
+
+func TestNtSecurityDescriptortoSDDL(t *testing.T) {
+	input := "O:BAG:SYD:(A;CIOI;GA;;;BA)S:(AU;SAFA;GA;;;WD)"
+	ntsd, err := sddl.SDDLtoNtSecurityDescriptor(input)
+	if err != nil {
+		t.Fatalf("SDDLtoNtSecurityDescriptor() error = %v", err)
+	}
+
+	output, err := sddl.NtSecurityDescriptortoSDDL(ntsd)
+	if err != nil {
+		t.Fatalf("NtSecurityDescriptortoSDDL() error = %v", err)
+	}
+
+	if output != input {
+		t.Errorf("Round-trip:\n  input:  %s\n  output: %s", input, output)
+	}
+}

--- a/sddl/sid/sid.go
+++ b/sddl/sid/sid.go
@@ -1,1 +1,82 @@
 package sid
+
+// SDDL SID abbreviation to full SID string mappings.
+// Source: https://learn.microsoft.com/en-us/windows/win32/secauthz/sid-strings
+
+var SDDLToSID = map[string]string{
+	// Well-known SIDs
+	"WD": "S-1-1-0",  // Everyone
+	"CO": "S-1-3-0",  // Creator Owner
+	"CG": "S-1-3-1",  // Creator Group
+	"OW": "S-1-3-4",  // Owner Rights
+	"NU": "S-1-5-2",  // Network
+	"IU": "S-1-5-4",  // Interactive
+	"SU": "S-1-5-6",  // Service
+	"AN": "S-1-5-7",  // Anonymous
+	"ED": "S-1-5-9",  // Enterprise Domain Controllers
+	"PS": "S-1-5-10", // Principal Self
+	"AU": "S-1-5-11", // Authenticated Users
+	"RC": "S-1-5-12", // Restricted Code
+	"SY": "S-1-5-18", // Local System
+	"LS": "S-1-5-19", // Local Service
+	"NS": "S-1-5-20", // Network Service
+
+	// BUILTIN groups
+	"BA": "S-1-5-32-544", // BUILTIN\Administrators
+	"BU": "S-1-5-32-545", // BUILTIN\Users
+	"BG": "S-1-5-32-546", // BUILTIN\Guests
+	"PU": "S-1-5-32-547", // BUILTIN\Power Users
+	"AO": "S-1-5-32-548", // BUILTIN\Account Operators
+	"SO": "S-1-5-32-549", // BUILTIN\Server Operators
+	"PO": "S-1-5-32-550", // BUILTIN\Print Operators
+	"BO": "S-1-5-32-551", // BUILTIN\Backup Operators
+	"RE": "S-1-5-32-552", // BUILTIN\Replicators
+	"RU": "S-1-5-32-554", // BUILTIN\Pre-Windows 2000 Compatible Access
+	"RD": "S-1-5-32-555", // BUILTIN\Remote Desktop Users
+	"NO": "S-1-5-32-556", // BUILTIN\Network Configuration Operators
+	"MU": "S-1-5-32-558", // BUILTIN\Performance Monitor Users
+	"LU": "S-1-5-32-559", // BUILTIN\Performance Log Users
+	"IS": "S-1-5-32-568", // BUILTIN\IIS_IUSRS
+	"CY": "S-1-5-32-569", // BUILTIN\Cryptographic Operators
+	"ER": "S-1-5-32-573", // BUILTIN\Event Log Readers
+	"CD": "S-1-5-32-574", // BUILTIN\Certificate Service DCOM Access
+	"RA": "S-1-5-32-575", // BUILTIN\RDS Remote Access Servers
+	"ES": "S-1-5-32-576", // BUILTIN\RDS Endpoint Servers
+	"MS": "S-1-5-32-577", // BUILTIN\RDS Management Servers
+	"HA": "S-1-5-32-578", // BUILTIN\Hyper-V Administrators
+	"AA": "S-1-5-32-579", // BUILTIN\Access Control Assistance Operators
+	"RM": "S-1-5-32-580", // BUILTIN\Remote Management Users
+
+	// Domain-relative SIDs (using placeholder domain 0-0-0)
+	"LA": "S-1-5-21-0-0-0-500", // Domain Administrator Account
+	"LG": "S-1-5-21-0-0-0-501", // Domain Guest Account
+	"DA": "S-1-5-21-0-0-0-512", // Domain Admins
+	"DU": "S-1-5-21-0-0-0-513", // Domain Users
+	"DG": "S-1-5-21-0-0-0-514", // Domain Guests
+	"DC": "S-1-5-21-0-0-0-515", // Domain Computers
+	"DD": "S-1-5-21-0-0-0-516", // Domain Controllers
+	"CA": "S-1-5-21-0-0-0-517", // Cert Publishers
+	"SA": "S-1-5-21-0-0-0-518", // Schema Admins
+	"EA": "S-1-5-21-0-0-0-519", // Enterprise Admins
+	"PA": "S-1-5-21-0-0-0-520", // Group Policy Creator Owners
+	"RO": "S-1-5-21-0-0-0-521", // Read-Only Domain Controllers
+	"CN": "S-1-5-21-0-0-0-522", // Cloneable Domain Controllers
+	"RS": "S-1-5-21-0-0-0-553", // RAS Servers Group
+
+	// Mandatory integrity levels
+	"LW": "S-1-16-4096",  // Low Integrity Level
+	"ME": "S-1-16-8192",  // Medium Integrity Level
+	"MP": "S-1-16-8448",  // Medium Plus Integrity Level
+	"HI": "S-1-16-12288", // High Integrity Level
+	"SI": "S-1-16-16384", // System Integrity Level
+}
+
+// SIDToSDDL is the reverse mapping from full SID strings to SDDL abbreviations.
+var SIDToSDDL map[string]string
+
+func init() {
+	SIDToSDDL = make(map[string]string, len(SDDLToSID))
+	for abbrev, sidStr := range SDDLToSID {
+		SIDToSDDL[sidStr] = abbrev
+	}
+}

--- a/securitydescriptor/NtSecurityDescriptor.go
+++ b/securitydescriptor/NtSecurityDescriptor.go
@@ -120,17 +120,6 @@ func (ntsd *NtSecurityDescriptor) Unmarshal(marshalledData []byte) (int, error) 
 	return int(ntsd.RawBytesSize), nil
 }
 
-// FromSDDLString initializes the NtSecurityDescriptor struct by parsing the SDDL string.
-//
-// Parameters:
-//   - sddlString (string): The SDDL string to be parsed.
-//
-// Returns:
-//   - error: An error if parsing fails, otherwise nil.
-func (ntsd *NtSecurityDescriptor) FromSDDLString(sddlString string) (int, error) {
-	return 0, fmt.Errorf("FromSDDLString is not yet implemented")
-}
-
 // Marshal serializes the NtSecurityDescriptor struct into a byte slice.
 //
 // Returns:

--- a/securitydescriptor/NtSecurityDescriptor_sddl.go
+++ b/securitydescriptor/NtSecurityDescriptor_sddl.go
@@ -1,0 +1,550 @@
+package securitydescriptor
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	ntsd_ace "github.com/TheManticoreProject/winacl/ace"
+	"github.com/TheManticoreProject/winacl/ace/aceflags"
+	"github.com/TheManticoreProject/winacl/ace/acetype"
+	"github.com/TheManticoreProject/winacl/acl"
+	"github.com/TheManticoreProject/winacl/acl/revision"
+	"github.com/TheManticoreProject/winacl/guid"
+	"github.com/TheManticoreProject/winacl/identity"
+	"github.com/TheManticoreProject/winacl/object"
+	"github.com/TheManticoreProject/winacl/object/flags"
+	"github.com/TheManticoreProject/winacl/securitydescriptor/control"
+	"github.com/TheManticoreProject/winacl/sid"
+
+	sddl_aceflags "github.com/TheManticoreProject/winacl/sddl/ace/aceflags"
+	sddl_acetype "github.com/TheManticoreProject/winacl/sddl/ace/acetype"
+	sddl_rights "github.com/TheManticoreProject/winacl/sddl/rights"
+	sddl_sid "github.com/TheManticoreProject/winacl/sddl/sid"
+)
+
+// FromSDDLString initializes the NtSecurityDescriptor struct by parsing the SDDL string.
+//
+// Parameters:
+//   - sddlString (string): The SDDL string to be parsed.
+//
+// Returns:
+//   - (int, error): Always returns 0 for the int value, and an error if parsing fails.
+func (ntsd *NtSecurityDescriptor) FromSDDLString(sddlString string) (int, error) {
+	ownerStr, groupStr, daclAces, saclAces := cutSDDL(sddlString)
+
+	ntsd.Header.Revision = 1
+
+	// Parse owner
+	if ownerStr != "" {
+		ownerSID, err := sddlParseSID(ownerStr)
+		if err != nil {
+			return 0, fmt.Errorf("failed to parse owner SID '%s': %w", ownerStr, err)
+		}
+		ntsd.Owner = &identity.Identity{SID: *ownerSID}
+		ntsd.Owner.Name = ownerSID.LookupName()
+	}
+
+	// Parse group
+	if groupStr != "" {
+		groupSID, err := sddlParseSID(groupStr)
+		if err != nil {
+			return 0, fmt.Errorf("failed to parse group SID '%s': %w", groupStr, err)
+		}
+		ntsd.Group = &identity.Identity{SID: *groupSID}
+		ntsd.Group.Name = groupSID.LookupName()
+	}
+
+	// Parse DACL
+	if len(daclAces) > 0 {
+		entries, err := sddlParseACL(daclAces)
+		if err != nil {
+			return 0, fmt.Errorf("failed to parse DACL: %w", err)
+		}
+		ntsd.DACL = &acl.DiscretionaryAccessControlList{
+			Header:  acl.DiscretionaryAccessControlListHeader{},
+			Entries: entries,
+		}
+		ntsd.DACL.Header.Revision.Value = sddlGetACLRevision(entries)
+		ntsd.DACL.Header.AceCount = uint16(len(entries))
+		ntsd.Header.Control.RawValue |= control.NT_SECURITY_DESCRIPTOR_CONTROL_DP
+	}
+
+	// Parse SACL
+	if len(saclAces) > 0 {
+		entries, err := sddlParseACL(saclAces)
+		if err != nil {
+			return 0, fmt.Errorf("failed to parse SACL: %w", err)
+		}
+		ntsd.SACL = &acl.SystemAccessControlList{
+			Header:  acl.SystemAccessControlListHeader{},
+			Entries: entries,
+		}
+		ntsd.SACL.Header.Revision.Value = sddlGetACLRevision(entries)
+		ntsd.SACL.Header.AceCount = uint16(len(entries))
+		ntsd.Header.Control.RawValue |= control.NT_SECURITY_DESCRIPTOR_CONTROL_SP
+	}
+
+	// Set self-relative flag
+	ntsd.Header.Control.RawValue |= control.NT_SECURITY_DESCRIPTOR_CONTROL_SR
+
+	return 0, nil
+}
+
+// ToSDDLString converts the NtSecurityDescriptor to an SDDL string representation.
+//
+// Returns:
+//   - (string, error): The SDDL string representation and any error that occurred.
+func (ntsd *NtSecurityDescriptor) ToSDDLString() (string, error) {
+	var sb strings.Builder
+
+	// Owner
+	if ntsd.Owner != nil {
+		sb.WriteString("O:")
+		sb.WriteString(sddlSIDToString(&ntsd.Owner.SID))
+	}
+
+	// Group
+	if ntsd.Group != nil {
+		sb.WriteString("G:")
+		sb.WriteString(sddlSIDToString(&ntsd.Group.SID))
+	}
+
+	// DACL
+	if ntsd.DACL != nil {
+		sb.WriteString("D:")
+		for _, entry := range ntsd.DACL.Entries {
+			aceStr, err := sddlACEToString(&entry)
+			if err != nil {
+				return "", fmt.Errorf("failed to convert DACL ACE to SDDL: %w", err)
+			}
+			sb.WriteString("(")
+			sb.WriteString(aceStr)
+			sb.WriteString(")")
+		}
+	}
+
+	// SACL
+	if ntsd.SACL != nil {
+		sb.WriteString("S:")
+		for _, entry := range ntsd.SACL.Entries {
+			aceStr, err := sddlACEToString(&entry)
+			if err != nil {
+				return "", fmt.Errorf("failed to convert SACL ACE to SDDL: %w", err)
+			}
+			sb.WriteString("(")
+			sb.WriteString(aceStr)
+			sb.WriteString(")")
+		}
+	}
+
+	return sb.String(), nil
+}
+
+// cutSDDL parses an SDDL string into its component parts.
+// This is a local copy to avoid circular imports with the sddl package.
+func cutSDDL(sddlString string) (string, string, []string, []string) {
+	sddlString = strings.TrimSpace(sddlString)
+	if len(sddlString) == 0 {
+		return "", "", nil, nil
+	}
+
+	components := map[string]string{
+		"O:": "",
+		"G:": "",
+		"D:": "",
+		"S:": "",
+	}
+
+	currentComponent := ""
+	k := 0
+	for k < len(sddlString) {
+		upperChar := strings.ToUpper(string(sddlString[k]))
+		if k+1 < len(sddlString) && (upperChar == "O" || upperChar == "G" || upperChar == "D" || upperChar == "S") && sddlString[k+1] == ':' {
+			currentComponent = strings.ToUpper(sddlString[k:k+2]) + ""
+			// Normalize to uppercase for map lookup
+			currentComponent = upperChar + ":"
+			k += 2
+			continue
+		}
+		if currentComponent != "" {
+			components[currentComponent] += string(sddlString[k])
+		}
+		k++
+	}
+
+	daclAces := cutAces(components["D:"])
+	saclAces := cutAces(components["S:"])
+
+	return components["O:"], components["G:"], daclAces, saclAces
+}
+
+// cutAces extracts individual ACE strings from a DACL/SACL component.
+func cutAces(aclStr string) []string {
+	var aces []string
+
+	start := strings.Index(aclStr, "(")
+	if start == -1 {
+		return aces
+	}
+
+	depth := 0
+	aceStart := start
+	for i := start; i < len(aclStr); i++ {
+		switch aclStr[i] {
+		case '(':
+			if depth == 0 {
+				aceStart = i + 1
+			}
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				aces = append(aces, aclStr[aceStart:i])
+			}
+		}
+	}
+
+	return aces
+}
+
+// sddlParseSID parses a SID from an SDDL string (abbreviation or full SID).
+func sddlParseSID(s string) (*sid.SID, error) {
+	s = strings.TrimSpace(s)
+
+	// Check if it's a well-known SDDL abbreviation
+	if fullSID, ok := sddl_sid.SDDLToSID[s]; ok {
+		s = fullSID
+	}
+
+	if !strings.HasPrefix(s, "S-") {
+		return nil, fmt.Errorf("unknown SID format: %s", s)
+	}
+
+	result := &sid.SID{}
+	err := result.FromString(s)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
+}
+
+// sddlSIDToString converts a SID to its SDDL string representation.
+func sddlSIDToString(s *sid.SID) string {
+	sidStr := s.ToString()
+	if abbrev, ok := sddl_sid.SIDToSDDL[sidStr]; ok {
+		return abbrev
+	}
+	return sidStr
+}
+
+// sddlParseACL parses a list of SDDL ACE strings into AccessControlEntry structs.
+func sddlParseACL(aceStrings []string) ([]ntsd_ace.AccessControlEntry, error) {
+	entries := make([]ntsd_ace.AccessControlEntry, 0, len(aceStrings))
+	for i, aceStr := range aceStrings {
+		entry, err := sddlParseACE(aceStr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse ACE #%d '%s': %w", i+1, aceStr, err)
+		}
+		entry.Index = uint16(i + 1)
+		entries = append(entries, *entry)
+	}
+	return entries, nil
+}
+
+// sddlParseACE parses a single SDDL ACE string.
+// Format: aceType;aceFlags;rights;objectGuid;inheritedObjectGuid;accountSid
+func sddlParseACE(aceStr string) (*ntsd_ace.AccessControlEntry, error) {
+	parts := strings.Split(aceStr, ";")
+	if len(parts) < 6 {
+		return nil, fmt.Errorf("invalid ACE string format, expected 6 semicolon-separated fields: %s", aceStr)
+	}
+
+	ace := &ntsd_ace.AccessControlEntry{}
+
+	// Parse ACE type
+	aceTypeStr := strings.TrimSpace(parts[0])
+	if typeVal, ok := sddl_acetype.SDDLToACETypeMap[aceTypeStr]; ok {
+		ace.Header.Type.Value = typeVal
+	} else {
+		return nil, fmt.Errorf("unknown ACE type: %s", aceTypeStr)
+	}
+
+	// Parse ACE flags
+	flagsStr := strings.TrimSpace(parts[1])
+	flagValue, err := sddlParseACEFlags(flagsStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse ACE flags '%s': %w", flagsStr, err)
+	}
+	ace.Header.Flags.RawValue = flagValue
+	ace.Header.Flags.Unmarshal([]byte{flagValue})
+
+	// Parse rights/mask
+	rightsStr := strings.TrimSpace(parts[2])
+	maskValue, err := sddlParseRights(rightsStr)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse rights '%s': %w", rightsStr, err)
+	}
+	ace.Mask.RawValue = maskValue
+
+	// Parse object GUID
+	objectGuidStr := strings.TrimSpace(parts[3])
+	inheritedGuidStr := strings.TrimSpace(parts[4])
+
+	if objectGuidStr != "" || inheritedGuidStr != "" {
+		ace.AccessControlObjectType = object.AccessControlObjectType{}
+
+		if objectGuidStr != "" {
+			g, err := guid.FromString(objectGuidStr)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse object GUID '%s': %w", objectGuidStr, err)
+			}
+			ace.AccessControlObjectType.ObjectType.GUID = *g
+			ace.AccessControlObjectType.Flags.Value |= flags.ACCESS_CONTROL_OBJECT_TYPE_FLAG_OBJECT_TYPE_PRESENT
+		}
+
+		if inheritedGuidStr != "" {
+			g, err := guid.FromString(inheritedGuidStr)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse inherited object GUID '%s': %w", inheritedGuidStr, err)
+			}
+			ace.AccessControlObjectType.InheritedObjectType.GUID = *g
+			ace.AccessControlObjectType.Flags.Value |= flags.ACCESS_CONTROL_OBJECT_TYPE_FLAG_INHERITED_OBJECT_TYPE_PRESENT
+		}
+	}
+
+	// Parse account SID
+	sidStr := strings.TrimSpace(parts[5])
+	if sidStr != "" {
+		parsedSID, err := sddlParseSID(sidStr)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse account SID '%s': %w", sidStr, err)
+		}
+		ace.Identity.SID = *parsedSID
+		ace.Identity.Name = parsedSID.LookupName()
+	}
+
+	return ace, nil
+}
+
+// sddlParseACEFlags parses an SDDL ACE flags string into a combined uint8 value.
+func sddlParseACEFlags(s string) (uint8, error) {
+	if s == "" {
+		return 0, nil
+	}
+
+	var result uint8
+	for i := 0; i+1 < len(s); i += 2 {
+		abbrev := s[i : i+2]
+		if flagVal, ok := sddl_aceflags.SDDLToACEFlag[abbrev]; ok {
+			result |= flagVal
+		} else {
+			return 0, fmt.Errorf("unknown ACE flag: %s", abbrev)
+		}
+	}
+	return result, nil
+}
+
+// sddlParseRights parses an SDDL rights string into a uint32 access mask.
+func sddlParseRights(s string) (uint32, error) {
+	if s == "" {
+		return 0, nil
+	}
+
+	// Check for hex value
+	if strings.HasPrefix(s, "0x") || strings.HasPrefix(s, "0X") {
+		val, err := strconv.ParseUint(s[2:], 16, 32)
+		if err != nil {
+			return 0, fmt.Errorf("invalid hex rights value: %s", s)
+		}
+		return uint32(val), nil
+	}
+
+	var result uint32
+	for i := 0; i+1 < len(s); i += 2 {
+		abbrev := s[i : i+2]
+		if rightVal, ok := sddl_rights.SDDLToRight[abbrev]; ok {
+			result |= rightVal
+		} else {
+			return 0, fmt.Errorf("unknown right: %s", abbrev)
+		}
+	}
+	return result, nil
+}
+
+// sddlACEToString converts an AccessControlEntry to its SDDL string.
+func sddlACEToString(ace *ntsd_ace.AccessControlEntry) (string, error) {
+	var parts [6]string
+
+	// ACE type
+	typeStr, err := sddlACETypeToString(ace.Header.Type.Value)
+	if err != nil {
+		return "", err
+	}
+	parts[0] = typeStr
+
+	// ACE flags
+	parts[1] = sddlACEFlagsToString(ace.Header.Flags.RawValue)
+
+	// Rights - pass ACE type for context-aware mapping
+	parts[2] = sddlRightsToString(ace.Mask.RawValue, ace.Header.Type.Value)
+
+	// Object GUID
+	if ace.AccessControlObjectType.Flags.Value&flags.ACCESS_CONTROL_OBJECT_TYPE_FLAG_OBJECT_TYPE_PRESENT != 0 {
+		parts[3] = ace.AccessControlObjectType.ObjectType.GUID.ToFormatD()
+	}
+
+	// Inherited object GUID
+	if ace.AccessControlObjectType.Flags.Value&flags.ACCESS_CONTROL_OBJECT_TYPE_FLAG_INHERITED_OBJECT_TYPE_PRESENT != 0 {
+		parts[4] = ace.AccessControlObjectType.InheritedObjectType.GUID.ToFormatD()
+	}
+
+	// Account SID
+	parts[5] = sddlSIDToString(&ace.Identity.SID)
+
+	return strings.Join(parts[:], ";"), nil
+}
+
+// sddlACETypeToString converts an ACE type value to its SDDL abbreviation.
+func sddlACETypeToString(typeVal uint8) (string, error) {
+	for sddl, val := range sddl_acetype.SDDLToACETypeMap {
+		if val == typeVal {
+			return sddl, nil
+		}
+	}
+	return "", fmt.Errorf("unknown ACE type value: 0x%02x", typeVal)
+}
+
+// sddlACEFlagsToString converts ACE flags to their SDDL string.
+func sddlACEFlagsToString(flagVal uint8) string {
+	if flagVal == 0 {
+		return ""
+	}
+
+	var sb strings.Builder
+	orderedFlags := []struct {
+		flag uint8
+		sddl string
+	}{
+		{aceflags.ACE_FLAG_CONTAINER_INHERIT, "CI"},
+		{aceflags.ACE_FLAG_OBJECT_INHERIT, "OI"},
+		{aceflags.ACE_FLAG_NO_PROPAGATE_INHERIT, "NP"},
+		{aceflags.ACE_FLAG_INHERIT_ONLY, "IO"},
+		{aceflags.ACE_FLAG_INHERITED, "ID"},
+		{aceflags.ACE_FLAG_SUCCESSFUL_ACCESS, "SA"},
+		{aceflags.ACE_FLAG_FAILED_ACCESS, "FA"},
+	}
+
+	for _, of := range orderedFlags {
+		if flagVal&of.flag != 0 {
+			sb.WriteString(of.sddl)
+		}
+	}
+
+	return sb.String()
+}
+
+// sddlRightsToString converts an access mask to its SDDL string.
+// The aceType parameter is used to disambiguate rights that share the same
+// bit value but have different SDDL abbreviations depending on context
+// (e.g. mandatory label rights NR/NW/NX vs DS rights CC/DC/LC).
+func sddlRightsToString(maskVal uint32, aceType uint8) string {
+	if maskVal == 0 {
+		return ""
+	}
+
+	// Try composite rights first (exact match)
+	compositeRights := []struct {
+		value uint32
+		sddl  string
+	}{
+		{0x001F01FF, "FA"}, // FILE_ALL_ACCESS
+		{0x000F003F, "KA"}, // KEY_ALL_ACCESS
+	}
+	for _, cr := range compositeRights {
+		if maskVal == cr.value {
+			return cr.sddl
+		}
+	}
+
+	// For mandatory label ACEs, use NR/NW/NX abbreviations
+	isMandatoryLabel := aceType == acetype.ACE_TYPE_SYSTEM_MANDATORY_LABEL
+
+	var sb strings.Builder
+	remaining := maskVal
+
+	if isMandatoryLabel {
+		mandatoryRights := []struct {
+			value uint32
+			sddl  string
+		}{
+			{0x00000001, "NR"}, // SYSTEM_MANDATORY_LABEL_NO_READ_UP
+			{0x00000002, "NW"}, // SYSTEM_MANDATORY_LABEL_NO_WRITE_UP
+			{0x00000004, "NX"}, // SYSTEM_MANDATORY_LABEL_NO_EXECUTE_UP
+		}
+		for _, mr := range mandatoryRights {
+			if remaining&mr.value == mr.value {
+				sb.WriteString(mr.sddl)
+				remaining &^= mr.value
+			}
+		}
+	}
+
+	orderedRights := []struct {
+		value uint32
+		sddl  string
+	}{
+		// Generic rights
+		{0x10000000, "GA"},
+		{0x80000000, "GR"},
+		{0x40000000, "GW"},
+		{0x20000000, "GX"},
+		// Standard rights
+		{0x00020000, "RC"},
+		{0x00010000, "SD"},
+		{0x00040000, "WD"},
+		{0x00080000, "WO"},
+		// DS rights
+		{0x00000010, "RP"},
+		{0x00000020, "WP"},
+		{0x00000001, "CC"},
+		{0x00000002, "DC"},
+		{0x00000004, "LC"},
+		{0x00000008, "SW"},
+		{0x00000080, "LO"},
+		{0x00000040, "DT"},
+		{0x00000100, "CR"},
+	}
+
+	for _, or := range orderedRights {
+		if remaining&or.value == or.value {
+			sb.WriteString(or.sddl)
+			remaining &^= or.value
+		}
+	}
+
+	if remaining != 0 {
+		sb.WriteString(fmt.Sprintf("0x%08x", remaining))
+	}
+
+	return sb.String()
+}
+
+// sddlGetACLRevision returns the appropriate ACL revision.
+func sddlGetACLRevision(entries []ntsd_ace.AccessControlEntry) uint8 {
+	for _, entry := range entries {
+		switch entry.Header.Type.Value {
+		case acetype.ACE_TYPE_ACCESS_ALLOWED_OBJECT,
+			acetype.ACE_TYPE_ACCESS_DENIED_OBJECT,
+			acetype.ACE_TYPE_SYSTEM_AUDIT_OBJECT,
+			acetype.ACE_TYPE_SYSTEM_ALARM_OBJECT,
+			acetype.ACE_TYPE_ACCESS_ALLOWED_CALLBACK_OBJECT,
+			acetype.ACE_TYPE_ACCESS_DENIED_CALLBACK_OBJECT,
+			acetype.ACE_TYPE_SYSTEM_AUDIT_CALLBACK_OBJECT,
+			acetype.ACE_TYPE_SYSTEM_ALARM_CALLBACK_OBJECT:
+			return revision.ACL_REVISION_DS
+		}
+	}
+	return revision.ACL_REVISION
+}

--- a/securitydescriptor/NtSecurityDescriptor_sddl.go
+++ b/securitydescriptor/NtSecurityDescriptor_sddl.go
@@ -31,7 +31,7 @@ import (
 // Returns:
 //   - (int, error): Always returns 0 for the int value, and an error if parsing fails.
 func (ntsd *NtSecurityDescriptor) FromSDDLString(sddlString string) (int, error) {
-	ownerStr, groupStr, daclAces, saclAces := cutSDDL(sddlString)
+	ownerStr, groupStr, daclFlags, daclAces, saclFlags, saclAces := cutSDDL(sddlString)
 
 	ntsd.Header.Revision = 1
 
@@ -56,10 +56,14 @@ func (ntsd *NtSecurityDescriptor) FromSDDLString(sddlString string) (int, error)
 	}
 
 	// Parse DACL
-	if len(daclAces) > 0 {
-		entries, err := sddlParseACL(daclAces)
-		if err != nil {
-			return 0, fmt.Errorf("failed to parse DACL: %w", err)
+	if len(daclAces) > 0 || daclFlags != "" {
+		var entries []ntsd_ace.AccessControlEntry
+		if len(daclAces) > 0 {
+			var err error
+			entries, err = sddlParseACL(daclAces)
+			if err != nil {
+				return 0, fmt.Errorf("failed to parse DACL: %w", err)
+			}
 		}
 		ntsd.DACL = &acl.DiscretionaryAccessControlList{
 			Header:  acl.DiscretionaryAccessControlListHeader{},
@@ -68,13 +72,26 @@ func (ntsd *NtSecurityDescriptor) FromSDDLString(sddlString string) (int, error)
 		ntsd.DACL.Header.Revision.Value = sddlGetACLRevision(entries)
 		ntsd.DACL.Header.AceCount = uint16(len(entries))
 		ntsd.Header.Control.RawValue |= control.NT_SECURITY_DESCRIPTOR_CONTROL_DP
+
+		// Parse DACL flags
+		if daclFlags != "" {
+			controlBits, err := sddlParseACLFlags(daclFlags, true)
+			if err != nil {
+				return 0, fmt.Errorf("failed to parse DACL flags '%s': %w", daclFlags, err)
+			}
+			ntsd.Header.Control.RawValue |= controlBits
+		}
 	}
 
 	// Parse SACL
-	if len(saclAces) > 0 {
-		entries, err := sddlParseACL(saclAces)
-		if err != nil {
-			return 0, fmt.Errorf("failed to parse SACL: %w", err)
+	if len(saclAces) > 0 || saclFlags != "" {
+		var entries []ntsd_ace.AccessControlEntry
+		if len(saclAces) > 0 {
+			var err error
+			entries, err = sddlParseACL(saclAces)
+			if err != nil {
+				return 0, fmt.Errorf("failed to parse SACL: %w", err)
+			}
 		}
 		ntsd.SACL = &acl.SystemAccessControlList{
 			Header:  acl.SystemAccessControlListHeader{},
@@ -83,6 +100,15 @@ func (ntsd *NtSecurityDescriptor) FromSDDLString(sddlString string) (int, error)
 		ntsd.SACL.Header.Revision.Value = sddlGetACLRevision(entries)
 		ntsd.SACL.Header.AceCount = uint16(len(entries))
 		ntsd.Header.Control.RawValue |= control.NT_SECURITY_DESCRIPTOR_CONTROL_SP
+
+		// Parse SACL flags
+		if saclFlags != "" {
+			controlBits, err := sddlParseACLFlags(saclFlags, false)
+			if err != nil {
+				return 0, fmt.Errorf("failed to parse SACL flags '%s': %w", saclFlags, err)
+			}
+			ntsd.Header.Control.RawValue |= controlBits
+		}
 	}
 
 	// Set self-relative flag
@@ -113,6 +139,7 @@ func (ntsd *NtSecurityDescriptor) ToSDDLString() (string, error) {
 	// DACL
 	if ntsd.DACL != nil {
 		sb.WriteString("D:")
+		sb.WriteString(sddlACLFlagsToString(ntsd.Header.Control.RawValue, true))
 		for _, entry := range ntsd.DACL.Entries {
 			aceStr, err := sddlACEToString(&entry)
 			if err != nil {
@@ -127,6 +154,7 @@ func (ntsd *NtSecurityDescriptor) ToSDDLString() (string, error) {
 	// SACL
 	if ntsd.SACL != nil {
 		sb.WriteString("S:")
+		sb.WriteString(sddlACLFlagsToString(ntsd.Header.Control.RawValue, false))
 		for _, entry := range ntsd.SACL.Entries {
 			aceStr, err := sddlACEToString(&entry)
 			if err != nil {
@@ -143,10 +171,11 @@ func (ntsd *NtSecurityDescriptor) ToSDDLString() (string, error) {
 
 // cutSDDL parses an SDDL string into its component parts.
 // This is a local copy to avoid circular imports with the sddl package.
-func cutSDDL(sddlString string) (string, string, []string, []string) {
+// Returns: owner, group, daclFlags, daclAces, saclFlags, saclAces
+func cutSDDL(sddlString string) (string, string, string, []string, string, []string) {
 	sddlString = strings.TrimSpace(sddlString)
 	if len(sddlString) == 0 {
-		return "", "", nil, nil
+		return "", "", "", nil, "", nil
 	}
 
 	components := map[string]string{
@@ -161,8 +190,6 @@ func cutSDDL(sddlString string) (string, string, []string, []string) {
 	for k < len(sddlString) {
 		upperChar := strings.ToUpper(string(sddlString[k]))
 		if k+1 < len(sddlString) && (upperChar == "O" || upperChar == "G" || upperChar == "D" || upperChar == "S") && sddlString[k+1] == ':' {
-			currentComponent = strings.ToUpper(sddlString[k:k+2]) + ""
-			// Normalize to uppercase for map lookup
 			currentComponent = upperChar + ":"
 			k += 2
 			continue
@@ -173,20 +200,23 @@ func cutSDDL(sddlString string) (string, string, []string, []string) {
 		k++
 	}
 
-	daclAces := cutAces(components["D:"])
-	saclAces := cutAces(components["S:"])
+	daclFlags, daclAces := cutAces(components["D:"])
+	saclFlags, saclAces := cutAces(components["S:"])
 
-	return components["O:"], components["G:"], daclAces, saclAces
+	return components["O:"], components["G:"], daclFlags, daclAces, saclFlags, saclAces
 }
 
-// cutAces extracts individual ACE strings from a DACL/SACL component.
-func cutAces(aclStr string) []string {
+// cutAces extracts the ACL flags prefix and individual ACE strings from a DACL/SACL component.
+func cutAces(aclStr string) (string, []string) {
 	var aces []string
 
 	start := strings.Index(aclStr, "(")
 	if start == -1 {
-		return aces
+		// No ACEs; everything is flags (or empty)
+		return strings.TrimSpace(aclStr), aces
 	}
+
+	aclFlags := strings.TrimSpace(aclStr[:start])
 
 	depth := 0
 	aceStart := start
@@ -205,7 +235,7 @@ func cutAces(aclStr string) []string {
 		}
 	}
 
-	return aces
+	return aclFlags, aces
 }
 
 // sddlParseSID parses a SID from an SDDL string (abbreviation or full SID).
@@ -334,6 +364,10 @@ func sddlParseACEFlags(s string) (uint8, error) {
 		return 0, nil
 	}
 
+	if len(s)%2 != 0 {
+		return 0, fmt.Errorf("invalid ACE flags string (odd length): %s", s)
+	}
+
 	var result uint8
 	for i := 0; i+1 < len(s); i += 2 {
 		abbrev := s[i : i+2]
@@ -359,6 +393,10 @@ func sddlParseRights(s string) (uint32, error) {
 			return 0, fmt.Errorf("invalid hex rights value: %s", s)
 		}
 		return uint32(val), nil
+	}
+
+	if len(s)%2 != 0 {
+		return 0, fmt.Errorf("invalid rights string (odd length): %s", s)
 	}
 
 	var result uint32
@@ -400,8 +438,10 @@ func sddlACEToString(ace *ntsd_ace.AccessControlEntry) (string, error) {
 		parts[4] = ace.AccessControlObjectType.InheritedObjectType.GUID.ToFormatD()
 	}
 
-	// Account SID
-	parts[5] = sddlSIDToString(&ace.Identity.SID)
+	// Account SID (only emit if the SID is initialized)
+	if ace.Identity.SID.RevisionLevel != 0 {
+		parts[5] = sddlSIDToString(&ace.Identity.SID)
+	}
 
 	return strings.Join(parts[:], ";"), nil
 }
@@ -526,6 +566,86 @@ func sddlRightsToString(maskVal uint32, aceType uint8) string {
 
 	if remaining != 0 {
 		sb.WriteString(fmt.Sprintf("0x%08x", remaining))
+	}
+
+	return sb.String()
+}
+
+// sddlParseACLFlags parses SDDL ACL flags (P, AI, AR, NO_ACCESS_CONTROL) into control bits.
+// isDACL determines whether the flags apply to the DACL or SACL.
+func sddlParseACLFlags(s string, isDACL bool) (uint16, error) {
+	var result uint16
+	i := 0
+	for i < len(s) {
+		remaining := s[i:]
+		matched := false
+
+		// Try two-character flags first
+		if len(remaining) >= 2 {
+			twoChar := strings.ToUpper(remaining[:2])
+			switch twoChar {
+			case "AI":
+				if isDACL {
+					result |= control.NT_SECURITY_DESCRIPTOR_CONTROL_DI
+				} else {
+					result |= control.NT_SECURITY_DESCRIPTOR_CONTROL_SI
+				}
+				i += 2
+				matched = true
+			case "AR":
+				if isDACL {
+					result |= control.NT_SECURITY_DESCRIPTOR_CONTROL_DC
+				} else {
+					result |= control.NT_SECURITY_DESCRIPTOR_CONTROL_SC
+				}
+				i += 2
+				matched = true
+			}
+		}
+
+		if !matched {
+			oneChar := strings.ToUpper(remaining[:1])
+			switch oneChar {
+			case "P":
+				if isDACL {
+					result |= control.NT_SECURITY_DESCRIPTOR_CONTROL_PD
+				} else {
+					result |= control.NT_SECURITY_DESCRIPTOR_CONTROL_PS
+				}
+				i++
+			default:
+				return 0, fmt.Errorf("unknown ACL flag at position %d: %s", i, remaining)
+			}
+		}
+	}
+	return result, nil
+}
+
+// sddlACLFlagsToString converts control bits to SDDL ACL flags string.
+// isDACL determines whether to check DACL or SACL control bits.
+func sddlACLFlagsToString(controlVal uint16, isDACL bool) string {
+	var sb strings.Builder
+
+	if isDACL {
+		if controlVal&control.NT_SECURITY_DESCRIPTOR_CONTROL_PD != 0 {
+			sb.WriteString("P")
+		}
+		if controlVal&control.NT_SECURITY_DESCRIPTOR_CONTROL_DI != 0 {
+			sb.WriteString("AI")
+		}
+		if controlVal&control.NT_SECURITY_DESCRIPTOR_CONTROL_DC != 0 {
+			sb.WriteString("AR")
+		}
+	} else {
+		if controlVal&control.NT_SECURITY_DESCRIPTOR_CONTROL_PS != 0 {
+			sb.WriteString("P")
+		}
+		if controlVal&control.NT_SECURITY_DESCRIPTOR_CONTROL_SI != 0 {
+			sb.WriteString("AI")
+		}
+		if controlVal&control.NT_SECURITY_DESCRIPTOR_CONTROL_SC != 0 {
+			sb.WriteString("AR")
+		}
 	}
 
 	return sb.String()

--- a/securitydescriptor/NtSecurityDescriptor_sddl_test.go
+++ b/securitydescriptor/NtSecurityDescriptor_sddl_test.go
@@ -1,0 +1,334 @@
+package securitydescriptor
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/winacl/ace/acetype"
+	"github.com/TheManticoreProject/winacl/object/flags"
+)
+
+func TestFromSDDLString_BasicOwnerGroup(t *testing.T) {
+	ntsd := NtSecurityDescriptor{}
+	_, err := ntsd.FromSDDLString("O:BAG:SY")
+	if err != nil {
+		t.Fatalf("FromSDDLString() error = %v", err)
+	}
+
+	if ntsd.Owner == nil {
+		t.Fatal("Owner should not be nil")
+	}
+	if ntsd.Owner.SID.ToString() != "S-1-5-32-544" {
+		t.Errorf("Owner SID = %s, want S-1-5-32-544", ntsd.Owner.SID.ToString())
+	}
+
+	if ntsd.Group == nil {
+		t.Fatal("Group should not be nil")
+	}
+	if ntsd.Group.SID.ToString() != "S-1-5-18" {
+		t.Errorf("Group SID = %s, want S-1-5-18", ntsd.Group.SID.ToString())
+	}
+}
+
+func TestFromSDDLString_FullSIDStrings(t *testing.T) {
+	ntsd := NtSecurityDescriptor{}
+	_, err := ntsd.FromSDDLString("O:S-1-5-32-544G:S-1-5-32-545")
+	if err != nil {
+		t.Fatalf("FromSDDLString() error = %v", err)
+	}
+
+	if ntsd.Owner.SID.ToString() != "S-1-5-32-544" {
+		t.Errorf("Owner SID = %s, want S-1-5-32-544", ntsd.Owner.SID.ToString())
+	}
+	if ntsd.Group.SID.ToString() != "S-1-5-32-545" {
+		t.Errorf("Group SID = %s, want S-1-5-32-545", ntsd.Group.SID.ToString())
+	}
+}
+
+func TestFromSDDLString_WithDACL(t *testing.T) {
+	ntsd := NtSecurityDescriptor{}
+	_, err := ntsd.FromSDDLString("O:BAG:BAD:(A;OICI;GA;;;BA)(A;OICI;GA;;;SY)")
+	if err != nil {
+		t.Fatalf("FromSDDLString() error = %v", err)
+	}
+
+	if ntsd.DACL == nil {
+		t.Fatal("DACL should not be nil")
+	}
+	if len(ntsd.DACL.Entries) != 2 {
+		t.Fatalf("DACL should have 2 entries, got %d", len(ntsd.DACL.Entries))
+	}
+
+	// First ACE: A;OICI;GA;;;BA
+	ace0 := ntsd.DACL.Entries[0]
+	if ace0.Header.Type.Value != acetype.ACE_TYPE_ACCESS_ALLOWED {
+		t.Errorf("ACE[0] type = 0x%02x, want ACCESS_ALLOWED (0x00)", ace0.Header.Type.Value)
+	}
+	if ace0.Header.Flags.RawValue != 0x03 { // OI|CI = 0x01|0x02
+		t.Errorf("ACE[0] flags = 0x%02x, want 0x03 (OI|CI)", ace0.Header.Flags.RawValue)
+	}
+	if ace0.Mask.RawValue != 0x10000000 { // GA
+		t.Errorf("ACE[0] mask = 0x%08x, want 0x10000000 (GA)", ace0.Mask.RawValue)
+	}
+	if ace0.Identity.SID.ToString() != "S-1-5-32-544" {
+		t.Errorf("ACE[0] SID = %s, want S-1-5-32-544 (BA)", ace0.Identity.SID.ToString())
+	}
+
+	// Second ACE: A;OICI;GA;;;SY
+	ace1 := ntsd.DACL.Entries[1]
+	if ace1.Identity.SID.ToString() != "S-1-5-18" {
+		t.Errorf("ACE[1] SID = %s, want S-1-5-18 (SY)", ace1.Identity.SID.ToString())
+	}
+}
+
+func TestFromSDDLString_WithSACL(t *testing.T) {
+	ntsd := NtSecurityDescriptor{}
+	_, err := ntsd.FromSDDLString("S:(AU;SAFA;GA;;;WD)")
+	if err != nil {
+		t.Fatalf("FromSDDLString() error = %v", err)
+	}
+
+	if ntsd.SACL == nil {
+		t.Fatal("SACL should not be nil")
+	}
+	if len(ntsd.SACL.Entries) != 1 {
+		t.Fatalf("SACL should have 1 entry, got %d", len(ntsd.SACL.Entries))
+	}
+
+	ace0 := ntsd.SACL.Entries[0]
+	if ace0.Header.Type.Value != acetype.ACE_TYPE_SYSTEM_AUDIT {
+		t.Errorf("ACE type = 0x%02x, want SYSTEM_AUDIT (0x02)", ace0.Header.Type.Value)
+	}
+	if ace0.Header.Flags.RawValue != 0xC0 { // SA|FA = 0x40|0x80
+		t.Errorf("ACE flags = 0x%02x, want 0xC0 (SA|FA)", ace0.Header.Flags.RawValue)
+	}
+	if ace0.Identity.SID.ToString() != "S-1-1-0" { // WD = Everyone
+		t.Errorf("ACE SID = %s, want S-1-1-0 (WD)", ace0.Identity.SID.ToString())
+	}
+}
+
+func TestFromSDDLString_ObjectACE(t *testing.T) {
+	ntsd := NtSecurityDescriptor{}
+	_, err := ntsd.FromSDDLString("D:(OA;;CCDC;bf967aba-0de6-11d0-a285-00aa003049e2;;BA)")
+	if err != nil {
+		t.Fatalf("FromSDDLString() error = %v", err)
+	}
+
+	if ntsd.DACL == nil || len(ntsd.DACL.Entries) != 1 {
+		t.Fatal("DACL should have 1 entry")
+	}
+
+	ace := ntsd.DACL.Entries[0]
+	if ace.Header.Type.Value != acetype.ACE_TYPE_ACCESS_ALLOWED_OBJECT {
+		t.Errorf("ACE type = 0x%02x, want ACCESS_ALLOWED_OBJECT (0x05)", ace.Header.Type.Value)
+	}
+
+	// Check object GUID
+	if ace.AccessControlObjectType.Flags.Value&flags.ACCESS_CONTROL_OBJECT_TYPE_FLAG_OBJECT_TYPE_PRESENT == 0 {
+		t.Error("Object type flag should be set")
+	}
+	guidStr := ace.AccessControlObjectType.ObjectType.GUID.ToFormatD()
+	if guidStr != "bf967aba-0de6-11d0-a285-00aa003049e2" {
+		t.Errorf("Object GUID = %s, want bf967aba-0de6-11d0-a285-00aa003049e2", guidStr)
+	}
+
+	// CC|DC = 0x01|0x02 = 0x03
+	if ace.Mask.RawValue != 0x03 {
+		t.Errorf("ACE mask = 0x%08x, want 0x00000003 (CC|DC)", ace.Mask.RawValue)
+	}
+}
+
+func TestFromSDDLString_ComplexSDDL(t *testing.T) {
+	sddlStr := "O:DAG:DAD:(A;;RPWPCCDCLCRCWOWDSDSW;;;SY)(A;;RPWPCCDCLCRCWOWDSDSW;;;DA)(OA;;CCDC;bf967aba-0de6-11d0-a285-00aa003049e2;;AO)(A;;RPLCRC;;;AU)S:(AU;SAFA;WDWOSDWPCCDCSW;;;WD)"
+	ntsd := NtSecurityDescriptor{}
+	_, err := ntsd.FromSDDLString(sddlStr)
+	if err != nil {
+		t.Fatalf("FromSDDLString() error = %v", err)
+	}
+
+	if ntsd.DACL == nil {
+		t.Fatal("DACL should not be nil")
+	}
+	if len(ntsd.DACL.Entries) != 4 {
+		t.Errorf("DACL should have 4 entries, got %d", len(ntsd.DACL.Entries))
+	}
+
+	if ntsd.SACL == nil {
+		t.Fatal("SACL should not be nil")
+	}
+	if len(ntsd.SACL.Entries) != 1 {
+		t.Errorf("SACL should have 1 entry, got %d", len(ntsd.SACL.Entries))
+	}
+}
+
+func TestToSDDLString_BasicOwnerGroup(t *testing.T) {
+	ntsd := NtSecurityDescriptor{}
+	_, err := ntsd.FromSDDLString("O:BAG:SY")
+	if err != nil {
+		t.Fatalf("FromSDDLString() error = %v", err)
+	}
+
+	sddlStr, err := ntsd.ToSDDLString()
+	if err != nil {
+		t.Fatalf("ToSDDLString() error = %v", err)
+	}
+
+	if sddlStr != "O:BAG:SY" {
+		t.Errorf("ToSDDLString() = %s, want O:BAG:SY", sddlStr)
+	}
+}
+
+func TestToSDDLString_WithDACL(t *testing.T) {
+	input := "O:BAG:BAD:(A;CIOI;GA;;;BA)(A;CIOI;GA;;;SY)"
+	ntsd := NtSecurityDescriptor{}
+	_, err := ntsd.FromSDDLString(input)
+	if err != nil {
+		t.Fatalf("FromSDDLString() error = %v", err)
+	}
+
+	sddlStr, err := ntsd.ToSDDLString()
+	if err != nil {
+		t.Fatalf("ToSDDLString() error = %v", err)
+	}
+
+	if sddlStr != input {
+		t.Errorf("ToSDDLString() = %s, want %s", sddlStr, input)
+	}
+}
+
+func TestToSDDLString_WithSACL(t *testing.T) {
+	input := "S:(AU;SAFA;GA;;;WD)"
+	ntsd := NtSecurityDescriptor{}
+	_, err := ntsd.FromSDDLString(input)
+	if err != nil {
+		t.Fatalf("FromSDDLString() error = %v", err)
+	}
+
+	sddlStr, err := ntsd.ToSDDLString()
+	if err != nil {
+		t.Fatalf("ToSDDLString() error = %v", err)
+	}
+
+	if sddlStr != input {
+		t.Errorf("ToSDDLString() = %s, want %s", sddlStr, input)
+	}
+}
+
+func TestToSDDLString_ObjectACE(t *testing.T) {
+	input := "D:(OA;;CCDC;bf967aba-0de6-11d0-a285-00aa003049e2;;BA)"
+	ntsd := NtSecurityDescriptor{}
+	_, err := ntsd.FromSDDLString(input)
+	if err != nil {
+		t.Fatalf("FromSDDLString() error = %v", err)
+	}
+
+	sddlStr, err := ntsd.ToSDDLString()
+	if err != nil {
+		t.Fatalf("ToSDDLString() error = %v", err)
+	}
+
+	if sddlStr != input {
+		t.Errorf("ToSDDLString() = %s, want %s", sddlStr, input)
+	}
+}
+
+func TestRoundTrip_ComplexSDDL(t *testing.T) {
+	// Test round-trip for various SDDL strings
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "Owner and group only",
+			input: "O:BAG:SY",
+		},
+		{
+			name:  "DACL with multiple ACEs",
+			input: "O:BAG:BAD:(A;CIOI;GA;;;BA)(A;CIOI;GA;;;SY)(A;CIOI;GA;;;CO)",
+		},
+		{
+			name:  "DACL and SACL",
+			input: "O:BAG:BAD:(A;CIOI;GA;;;BA)(A;CIOI;GA;;;SY)S:(AU;SAFA;GA;;;WD)",
+		},
+		{
+			name:  "Full SID strings that are not well-known",
+			input: "O:S-1-5-21-123-456-789-1000G:S-1-5-21-123-456-789-1001D:(A;ID;GA;;;S-1-5-21-123-456-789-1002)",
+		},
+		{
+			name:  "Object ACE with GUID",
+			input: "D:(OA;;CCDC;bf967aba-0de6-11d0-a285-00aa003049e2;;BA)",
+		},
+		{
+			name:  "Mandatory label",
+			input: "S:(ML;;NW;;;HI)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ntsd := NtSecurityDescriptor{}
+			_, err := ntsd.FromSDDLString(tt.input)
+			if err != nil {
+				t.Fatalf("FromSDDLString(%s) error = %v", tt.input, err)
+			}
+
+			output, err := ntsd.ToSDDLString()
+			if err != nil {
+				t.Fatalf("ToSDDLString() error = %v", err)
+			}
+
+			if output != tt.input {
+				t.Errorf("Round-trip failed:\n  input:  %s\n  output: %s", tt.input, output)
+			}
+		})
+	}
+}
+
+func TestFromSDDLString_MarshalRoundTrip(t *testing.T) {
+	// Parse SDDL, marshal to binary, unmarshal from binary, convert back to SDDL
+	input := "O:BAG:BAD:(A;CIOI;GA;;;BA)(A;CIOI;GA;;;SY)"
+
+	ntsd1 := NtSecurityDescriptor{}
+	_, err := ntsd1.FromSDDLString(input)
+	if err != nil {
+		t.Fatalf("FromSDDLString() error = %v", err)
+	}
+
+	// Marshal to binary
+	data, err := ntsd1.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+
+	// Unmarshal from binary
+	ntsd2 := NtSecurityDescriptor{}
+	_, err = ntsd2.Unmarshal(data)
+	if err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+
+	// Convert back to SDDL
+	output, err := ntsd2.ToSDDLString()
+	if err != nil {
+		t.Fatalf("ToSDDLString() error = %v", err)
+	}
+
+	if output != input {
+		t.Errorf("SDDL->Binary->SDDL round-trip failed:\n  input:  %s\n  output: %s", input, output)
+	}
+}
+
+func TestSDDLtoNtSecurityDescriptor_via_sddl_package(t *testing.T) {
+	// Test the sddl package wrapper functions work
+	ntsd := NtSecurityDescriptor{}
+	_, err := ntsd.FromSDDLString("O:BAG:BAD:(A;;GA;;;WD)")
+	if err != nil {
+		t.Fatalf("FromSDDLString() error = %v", err)
+	}
+
+	if ntsd.Owner == nil || ntsd.Owner.SID.ToString() != "S-1-5-32-544" {
+		t.Error("Owner should be BA (S-1-5-32-544)")
+	}
+	if ntsd.DACL == nil || len(ntsd.DACL.Entries) != 1 {
+		t.Error("Should have 1 DACL entry")
+	}
+}

--- a/securitydescriptor/NtSecurityDescriptor_sddl_test.go
+++ b/securitydescriptor/NtSecurityDescriptor_sddl_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/TheManticoreProject/winacl/ace/acetype"
 	"github.com/TheManticoreProject/winacl/object/flags"
+	"github.com/TheManticoreProject/winacl/securitydescriptor/control"
 )
 
 func TestFromSDDLString_BasicOwnerGroup(t *testing.T) {
@@ -314,6 +315,153 @@ func TestFromSDDLString_MarshalRoundTrip(t *testing.T) {
 
 	if output != input {
 		t.Errorf("SDDL->Binary->SDDL round-trip failed:\n  input:  %s\n  output: %s", input, output)
+	}
+}
+
+func TestFromSDDLString_OddLengthFlagsError(t *testing.T) {
+	ntsd := NtSecurityDescriptor{}
+	_, err := ntsd.FromSDDLString("D:(A;OIC;GA;;;WD)")
+	if err == nil {
+		t.Fatal("expected error for odd-length ACE flags string 'OIC', got nil")
+	}
+}
+
+func TestFromSDDLString_OddLengthRightsError(t *testing.T) {
+	ntsd := NtSecurityDescriptor{}
+	_, err := ntsd.FromSDDLString("D:(A;;GAR;;;WD)")
+	if err == nil {
+		t.Fatal("expected error for odd-length rights string 'GAR', got nil")
+	}
+}
+
+func TestFromSDDLString_ACLFlags(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		checkDACL bool
+		checkSACL bool
+		wantPD    bool // DACL Protected
+		wantDI    bool // DACL Auto-Inherited
+		wantDC    bool // DACL Auto-Inherit Required
+		wantPS    bool // SACL Protected
+		wantSI    bool // SACL Auto-Inherited
+		wantSC    bool // SACL Auto-Inherit Required
+	}{
+		{
+			name:      "DACL Protected",
+			input:     "D:P(A;;GA;;;WD)",
+			checkDACL: true,
+			wantPD:    true,
+		},
+		{
+			name:      "DACL Auto-Inherited",
+			input:     "D:AI(A;;GA;;;WD)",
+			checkDACL: true,
+			wantDI:    true,
+		},
+		{
+			name:      "DACL Protected and Auto-Inherited",
+			input:     "D:PAI(A;;GA;;;WD)",
+			checkDACL: true,
+			wantPD:    true,
+			wantDI:    true,
+		},
+		{
+			name:      "DACL Auto-Inherit Required",
+			input:     "D:AR(A;;GA;;;WD)",
+			checkDACL: true,
+			wantDC:    true,
+		},
+		{
+			name:      "SACL Protected",
+			input:     "S:P(AU;SAFA;GA;;;WD)",
+			checkSACL: true,
+			wantPS:    true,
+		},
+		{
+			name:      "SACL Auto-Inherited",
+			input:     "S:AI(AU;SAFA;GA;;;WD)",
+			checkSACL: true,
+			wantSI:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ntsd := NtSecurityDescriptor{}
+			_, err := ntsd.FromSDDLString(tt.input)
+			if err != nil {
+				t.Fatalf("FromSDDLString(%s) error = %v", tt.input, err)
+			}
+
+			ctrl := ntsd.Header.Control.RawValue
+
+			if tt.wantPD && ctrl&control.NT_SECURITY_DESCRIPTOR_CONTROL_PD == 0 {
+				t.Error("expected DACL Protected (PD) control bit to be set")
+			}
+			if tt.wantDI && ctrl&control.NT_SECURITY_DESCRIPTOR_CONTROL_DI == 0 {
+				t.Error("expected DACL Auto-Inherited (DI) control bit to be set")
+			}
+			if tt.wantDC && ctrl&control.NT_SECURITY_DESCRIPTOR_CONTROL_DC == 0 {
+				t.Error("expected DACL Auto-Inherit Required (DC) control bit to be set")
+			}
+			if tt.wantPS && ctrl&control.NT_SECURITY_DESCRIPTOR_CONTROL_PS == 0 {
+				t.Error("expected SACL Protected (PS) control bit to be set")
+			}
+			if tt.wantSI && ctrl&control.NT_SECURITY_DESCRIPTOR_CONTROL_SI == 0 {
+				t.Error("expected SACL Auto-Inherited (SI) control bit to be set")
+			}
+			if tt.wantSC && ctrl&control.NT_SECURITY_DESCRIPTOR_CONTROL_SC == 0 {
+				t.Error("expected SACL Auto-Inherit Required (SC) control bit to be set")
+			}
+		})
+	}
+}
+
+func TestRoundTrip_ACLFlags(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+	}{
+		{
+			name:  "DACL Protected",
+			input: "D:P(A;;GA;;;WD)",
+		},
+		{
+			name:  "DACL Auto-Inherited",
+			input: "D:AI(A;;GA;;;WD)",
+		},
+		{
+			name:  "DACL Protected and Auto-Inherited",
+			input: "D:PAI(A;;GA;;;WD)",
+		},
+		{
+			name:  "SACL Protected and Auto-Inherited",
+			input: "S:PAI(AU;SAFA;GA;;;WD)",
+		},
+		{
+			name:  "Both DACL and SACL flags",
+			input: "D:PAI(A;;GA;;;WD)S:AI(AU;SAFA;GA;;;WD)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ntsd := NtSecurityDescriptor{}
+			_, err := ntsd.FromSDDLString(tt.input)
+			if err != nil {
+				t.Fatalf("FromSDDLString(%s) error = %v", tt.input, err)
+			}
+
+			output, err := ntsd.ToSDDLString()
+			if err != nil {
+				t.Fatalf("ToSDDLString() error = %v", err)
+			}
+
+			if output != tt.input {
+				t.Errorf("Round-trip failed:\n  input:  %s\n  output: %s", tt.input, output)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds `ntsd.FromSDDLString()` to parse SDDL strings into `NtSecurityDescriptor` structs
- Adds `ntsd.ToSDDLString()` to serialize `NtSecurityDescriptor` structs back to SDDL strings
- Supports all standard ACE types, flags, access rights, well-known SID abbreviations, object ACEs with GUIDs, and domain-relative SIDs
- Full round-trip fidelity: SDDL -> struct -> SDDL and SDDL -> binary -> SDDL
- Populates the previously empty `sddl/sid`, `sddl/rights`, and `sddl/ace/aceflags` packages with mapping tables
- Updates `sddl.SDDLtoNtSecurityDescriptor()` and `sddl.NtSecurityDescriptortoSDDL()` wrapper functions to delegate to the new methods

## Test plan
- [x] All existing tests pass
- [x] FromSDDLString parses owner, group, DACL, SACL correctly
- [x] Object ACEs with GUIDs parse and round-trip correctly
- [x] Mandatory label ACEs use NR/NW/NX rights correctly
- [x] Complex SDDL strings with all components round-trip
- [x] SDDL -> Marshal -> Unmarshal -> SDDL round-trip works
- [x] sddl package wrapper functions work correctly