### PR TITLE
[bug] Fix SID.Marshal omitting RID when value is zero (#60)

### DIFF
--- a/sid/SecurityIdentifier.go
+++ b/sid/SecurityIdentifier.go
@@ -353,8 +353,10 @@ func (sid *SID) Marshal() ([]byte, error) {
 		marshalledData = append(marshalledData, buf[:]...)
 	}
 
-	if sid.RelativeIdentifier != 0 {
-		// Add the Relative Identifier (4 bytes, little-endian)
+	// The RID is the last sub-authority and must be serialized whenever the
+	// model indicates one exists (SubAuthorityCount > len(SubAuthorities)),
+	// including when its value is zero (e.g. S-1-1-0, S-1-0-0, S-1-3-0).
+	if uint8(len(sid.SubAuthorities)) < sid.SubAuthorityCount {
 		relativeIdentifierBytes := make([]byte, 4)
 		binary.LittleEndian.PutUint32(relativeIdentifierBytes, sid.RelativeIdentifier)
 		marshalledData = append(marshalledData, relativeIdentifierBytes...)

--- a/sid/SecurityIdentifier_test.go
+++ b/sid/SecurityIdentifier_test.go
@@ -344,3 +344,56 @@ func Test_SID_ToString(t *testing.T) {
 		t.Errorf("ToString() failed: expected %s, got %s", "S-1-16-49152", sid.ToString())
 	}
 }
+
+// Test_SID_Marshal_ZeroRID verifies that SIDs whose RID is zero still emit the
+// full 8 + 4*SubAuthorityCount binary layout mandated by MS-DTYP 2.4.2. This
+// covers well-known SIDs such as S-1-1-0 (Everyone), S-1-0-0 (Nobody), and
+// S-1-3-0 (Creator Owner).
+func Test_SID_Marshal_ZeroRID(t *testing.T) {
+	cases := []struct {
+		sidString string
+		expected  string
+	}{
+		{"S-1-1-0", "010100000000000100000000"}, // Everyone
+		{"S-1-0-0", "010100000000000000000000"}, // Nobody
+		{"S-1-3-0", "010100000000000300000000"}, // Creator Owner
+	}
+	for _, tc := range cases {
+		t.Run(tc.sidString, func(t *testing.T) {
+			s := &sid.SID{}
+			if err := s.FromString(tc.sidString); err != nil {
+				t.Fatalf("FromString(%s) error = %v", tc.sidString, err)
+			}
+			got, err := s.Marshal()
+			if err != nil {
+				t.Fatalf("Marshal() error = %v", err)
+			}
+			if hex.EncodeToString(got) != tc.expected {
+				t.Errorf("Marshal(%s) = %s, want %s", tc.sidString, hex.EncodeToString(got), tc.expected)
+			}
+			expectedLen := 8 + 4*int(s.SubAuthorityCount)
+			if len(got) != expectedLen {
+				t.Errorf("Marshal(%s) length = %d, want %d (per 8 + 4*SubAuthorityCount)", tc.sidString, len(got), expectedLen)
+			}
+		})
+	}
+}
+
+// Test_SID_UnmarshalMarshal_ZeroRID verifies that parsing a genuine 12-byte
+// binary for a zero-RID SID and re-marshalling preserves the exact bytes.
+func Test_SID_UnmarshalMarshal_ZeroRID(t *testing.T) {
+	// Windows binary for S-1-1-0 (Everyone): rev=1, SAC=1, auth=1, RID=0
+	raw, _ := hex.DecodeString("010100000000000100000000")
+	s := &sid.SID{}
+	if _, err := s.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	got, err := s.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	if !bytes.Equal(raw, got) {
+		t.Errorf("Unmarshal then Marshal did not round-trip: got %s, want %s",
+			hex.EncodeToString(got), hex.EncodeToString(raw))
+	}
+}


### PR DESCRIPTION
### Linked Issue
Closes #60

### Root Cause
`(*SID).Marshal()` guarded the RID write with `if sid.RelativeIdentifier != 0`. The model invariant set by `FromString` is that `SubAuthorities` holds the first `SubAuthorityCount - 1` values and the last sub-authority is stored separately in `RelativeIdentifier`. The RID is a structural sub-authority slot, not an optional field — treating zero as "absent" drops the last 4 bytes for any SID whose RID happens to be zero (`S-1-1-0` Everyone, `S-1-0-0` Nobody, `S-1-3-0` Creator Owner, among others), producing a binary that disagrees with its own `SubAuthorityCount` byte and violates the size rule `8 + 4 * SubAuthorityCount` from MS-DTYP 2.4.2.

### Fix Description
Replace the zero-value guard with a structural check: write the RID whenever the model indicates one exists, i.e. `len(SubAuthorities) < SubAuthorityCount`. This preserves the serialization invariant regardless of RID value.

### How Verified
- **Tests:** Added `Test_SID_Marshal_ZeroRID` asserting exact 12-byte output for `S-1-1-0`, `S-1-0-0`, `S-1-3-0`; added `Test_SID_UnmarshalMarshal_ZeroRID` asserting byte-exact round-trip of a genuine Windows binary for Everyone.
- **Static:** For SIDs with non-zero RID, `len(SubAuthorities) < SubAuthorityCount` remains true (same behaviour as before). For SIDs with `SubAuthorityCount == 0` (no sub-authorities modelled), the condition is false and nothing is written, also matching prior behaviour.
- **Runtime:** Full existing test suite (`go test ./...`) passes unchanged.

### Test Coverage
**Added:**
- `sid/SecurityIdentifier_test.go::Test_SID_Marshal_ZeroRID` — parameterized over three well-known zero-RID SIDs; asserts exact hex and `8 + 4*SubAuthorityCount` length.
- `sid/SecurityIdentifier_test.go::Test_SID_UnmarshalMarshal_ZeroRID` — parses real Windows binary for `S-1-1-0`, re-marshals, asserts byte equality.

### Scope of Change
- **Files changed:** `sid/SecurityIdentifier.go`, `sid/SecurityIdentifier_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Low blast radius — the change only affects serialized output for SIDs that previously emitted a malformed short binary. Consumers that happened to depend on the truncated output (unlikely, since it is invalid) would see 4 additional bytes for zero-RID SIDs. Safe to merge without staged rollout.