### PR TITLE
[bug] Fix FromSDDLString silently dropping ACEs on unbalanced parens (#62)

### DIFF
--- a/securitydescriptor/NtSecurityDescriptor_sddl.go
+++ b/securitydescriptor/NtSecurityDescriptor_sddl.go
@@ -31,7 +31,10 @@ import (
 // Returns:
 //   - (int, error): Always returns 0 for the int value, and an error if parsing fails.
 func (ntsd *NtSecurityDescriptor) FromSDDLString(sddlString string) (int, error) {
-	ownerStr, groupStr, daclFlags, daclAces, saclFlags, saclAces := cutSDDL(sddlString)
+	ownerStr, groupStr, daclFlags, daclAces, saclFlags, saclAces, err := cutSDDL(sddlString)
+	if err != nil {
+		return 0, fmt.Errorf("failed to parse SDDL: %w", err)
+	}
 
 	ntsd.Header.Revision = 1
 
@@ -171,11 +174,11 @@ func (ntsd *NtSecurityDescriptor) ToSDDLString() (string, error) {
 
 // cutSDDL parses an SDDL string into its component parts.
 // This is a local copy to avoid circular imports with the sddl package.
-// Returns: owner, group, daclFlags, daclAces, saclFlags, saclAces
-func cutSDDL(sddlString string) (string, string, string, []string, string, []string) {
+// Returns: owner, group, daclFlags, daclAces, saclFlags, saclAces, error
+func cutSDDL(sddlString string) (string, string, string, []string, string, []string, error) {
 	sddlString = strings.TrimSpace(sddlString)
 	if len(sddlString) == 0 {
-		return "", "", "", nil, "", nil
+		return "", "", "", nil, "", nil, nil
 	}
 
 	components := map[string]string{
@@ -200,20 +203,27 @@ func cutSDDL(sddlString string) (string, string, string, []string, string, []str
 		k++
 	}
 
-	daclFlags, daclAces := cutAces(components["D:"])
-	saclFlags, saclAces := cutAces(components["S:"])
+	daclFlags, daclAces, err := cutAces(components["D:"])
+	if err != nil {
+		return "", "", "", nil, "", nil, fmt.Errorf("DACL: %w", err)
+	}
+	saclFlags, saclAces, err := cutAces(components["S:"])
+	if err != nil {
+		return "", "", "", nil, "", nil, fmt.Errorf("SACL: %w", err)
+	}
 
-	return components["O:"], components["G:"], daclFlags, daclAces, saclFlags, saclAces
+	return components["O:"], components["G:"], daclFlags, daclAces, saclFlags, saclAces, nil
 }
 
 // cutAces extracts the ACL flags prefix and individual ACE strings from a DACL/SACL component.
-func cutAces(aclStr string) (string, []string) {
+// Returns an error if parentheses are unbalanced, so malformed input cannot be silently accepted.
+func cutAces(aclStr string) (string, []string, error) {
 	var aces []string
 
 	start := strings.Index(aclStr, "(")
 	if start == -1 {
 		// No ACEs; everything is flags (or empty)
-		return strings.TrimSpace(aclStr), aces
+		return strings.TrimSpace(aclStr), aces, nil
 	}
 
 	aclFlags := strings.TrimSpace(aclStr[:start])
@@ -228,6 +238,9 @@ func cutAces(aclStr string) (string, []string) {
 			}
 			depth++
 		case ')':
+			if depth == 0 {
+				return "", nil, fmt.Errorf("unbalanced ')' at position %d", i)
+			}
 			depth--
 			if depth == 0 {
 				aces = append(aces, aclStr[aceStart:i])
@@ -235,7 +248,11 @@ func cutAces(aclStr string) (string, []string) {
 		}
 	}
 
-	return aclFlags, aces
+	if depth != 0 {
+		return "", nil, fmt.Errorf("unclosed '(' starting at position %d", aceStart-1)
+	}
+
+	return aclFlags, aces, nil
 }
 
 // sddlParseSID parses a SID from an SDDL string (abbreviation or full SID).

--- a/securitydescriptor/NtSecurityDescriptor_sddl_test.go
+++ b/securitydescriptor/NtSecurityDescriptor_sddl_test.go
@@ -326,6 +326,27 @@ func TestFromSDDLString_OddLengthFlagsError(t *testing.T) {
 	}
 }
 
+func TestFromSDDLString_UnbalancedParenthesesError(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+	}{
+		{name: "unclosed DACL paren", input: "O:BAG:SYD:(A;;GA;;;WD"},
+		{name: "unclosed SACL paren", input: "S:(AU;SAFA;GA;;;WD"},
+		{name: "stray closing paren", input: "D:(A;;GA;;;WD))"},
+		{name: "unclosed after ACEs", input: "D:(A;;GA;;;WD)(A;;GA;;;SY"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ntsd := NtSecurityDescriptor{}
+			_, err := ntsd.FromSDDLString(tc.input)
+			if err == nil {
+				t.Fatalf("expected error for malformed SDDL %q, got nil", tc.input)
+			}
+		})
+	}
+}
+
 func TestFromSDDLString_OddLengthRightsError(t *testing.T) {
 	ntsd := NtSecurityDescriptor{}
 	_, err := ntsd.FromSDDLString("D:(A;;GAR;;;WD)")


### PR DESCRIPTION
### Linked Issue
Closes #62

### Root Cause
`cutAces` in `securitydescriptor/NtSecurityDescriptor_sddl.go` walked the SDDL ACL region tracking parenthesis depth but only appended to the ACE slice inside the `depth == 0` branch of the `)` case. When the input ended with `depth != 0`, the accumulated ACE content was silently discarded. The function's signature `(string, []string)` had no error channel, so `cutSDDL` and `FromSDDLString` had no way to distinguish "no ACEs present" from "ACEs lost to a malformed input." A stray `)` (which underflows `depth` to `-1`) also went undetected.

### Fix Description
- `cutAces` now returns `(string, []string, error)`:
  - Returns an error if a `)` appears while `depth == 0` ("unbalanced `)`").
  - Returns an error if the scan completes with `depth != 0` ("unclosed `(`").
- `cutSDDL` returns the same error, wrapped with the originating region name (`DACL` or `SACL`).
- `FromSDDLString` propagates the error prefixed with `failed to parse SDDL`.

### How Verified
- **Tests:** Added `TestFromSDDLString_UnbalancedParenthesesError` with four input shapes (unclosed DACL paren, unclosed SACL paren, stray `)`, unclosed trailing ACE) — each asserts a non-nil error.
- **Runtime:** `go test ./...` passes, including every existing SDDL round-trip test.

### Test Coverage
**Added:**
- `securitydescriptor/NtSecurityDescriptor_sddl_test.go::TestFromSDDLString_UnbalancedParenthesesError` — four sub-tests covering the distinct malformed-paren shapes.

### Scope of Change
- **Files changed:** `securitydescriptor/NtSecurityDescriptor_sddl.go`, `securitydescriptor/NtSecurityDescriptor_sddl_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — `cutAces` and `cutSDDL` are unexported, so the signature change is package-local. Every valid SDDL input that previously parsed continues to parse.

### Risk and Rollout
Narrow blast radius. The two helper signatures change but both are unexported; the only external caller is `FromSDDLString`, which is updated in the same PR. Safe to merge without staged rollout.

### Notes
The public `sddl.CutSDDL` / `sddl.CutAces` helpers in `sddl/sddl.go` have the same structural issue but their signatures are part of the public API; that will be addressed separately.