### PR TITLE
[bug] Fix sddl.CutSDDL silently dropping lowercase-marker components (#64)

### DIFF
--- a/sddl/sddl.go
+++ b/sddl/sddl.go
@@ -31,7 +31,10 @@ func CutSDDL(sddlString string) (string, string, []string, []string) {
 	for k < len(sddlString) {
 		upperChar := strings.ToUpper(string(sddlString[k]))
 		if k+1 < len(sddlString) && (upperChar == "O" || upperChar == "G" || upperChar == "D" || upperChar == "S") && sddlString[k+1] == ':' {
-			currentComponent = sddlString[k : k+2]
+			// Normalise the key to uppercase so lowercase markers (o:, g:, d:, s:)
+			// land in the same bucket as their uppercase counterparts; SDDL is
+			// case-insensitive at the component-marker level.
+			currentComponent = upperChar + ":"
 			k += 2
 			continue
 		}

--- a/sddl/sddl_test.go
+++ b/sddl/sddl_test.go
@@ -101,6 +101,58 @@ func TestSddlCut(t *testing.T) {
 	}
 }
 
+// TestSddlCut_LowercaseMarkers verifies that CutSDDL normalises lowercase
+// component markers (o:, g:, d:, s:) the same way as their uppercase
+// counterparts, matching SDDL's case-insensitive grammar.
+func TestSddlCut_LowercaseMarkers(t *testing.T) {
+	tests := []struct {
+		name         string
+		input        string
+		wantOwner    string
+		wantGroup    string
+		wantDaclAces []string
+		wantSaclAces []string
+	}{
+		{
+			name:         "all lowercase markers",
+			input:        "o:BAg:SYd:(A;;GA;;;WD)",
+			wantOwner:    "BA",
+			wantGroup:    "SY",
+			wantDaclAces: []string{"A;;GA;;;WD"},
+		},
+		{
+			name:      "mixed case markers",
+			input:     "O:BAg:SY",
+			wantOwner: "BA",
+			wantGroup: "SY",
+		},
+		{
+			name:         "lowercase s: SACL only",
+			input:        "s:(AU;SA;FA;;;WD)",
+			wantSaclAces: []string{"AU;SA;FA;;;WD"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotOwner, gotGroup, gotDaclAces, gotSaclAces := sddl.CutSDDL(tt.input)
+
+			if gotOwner != tt.wantOwner {
+				t.Errorf("CutSDDL() owner = %q, want %q", gotOwner, tt.wantOwner)
+			}
+			if gotGroup != tt.wantGroup {
+				t.Errorf("CutSDDL() group = %q, want %q", gotGroup, tt.wantGroup)
+			}
+			if !slices.Equal(gotDaclAces, tt.wantDaclAces) {
+				t.Errorf("CutSDDL() daclAces = %v, want %v", gotDaclAces, tt.wantDaclAces)
+			}
+			if !slices.Equal(gotSaclAces, tt.wantSaclAces) {
+				t.Errorf("CutSDDL() saclAces = %v, want %v", gotSaclAces, tt.wantSaclAces)
+			}
+		})
+	}
+}
+
 // func TestSDDLToBinary(t *testing.T) {
 // 	tests := []struct {
 // 		name    string


### PR DESCRIPTION
### Linked Issue
Closes #64

### Root Cause
`sddl.CutSDDL` compared the first character of each component marker case-insensitively (via `strings.ToUpper`) but then stored the marker using the *original* case from the input, `sddlString[k : k+2]`. The `components` map is created with only uppercase keys (`O:`, `G:`, `D:`, `S:`). When a lowercase marker such as `o:` matched, the appended bytes were written to `components["o:"]` — a key never read by the later `components["O:"]` / `components["D:"]` lookups — so every output was empty. The private `cutSDDL` in `securitydescriptor/NtSecurityDescriptor_sddl.go` already normalises to uppercase, so this fix just brings the public helper in line with the intended behaviour.

### Fix Description
Use the already-computed `upperChar + ":"` as the map key, matching the private implementation. No change to marker detection or to the walk loop; only the stored key is normalised.

### How Verified
- **Tests:** Added `TestSddlCut_LowercaseMarkers` with three input shapes (all-lowercase, mixed-case, lowercase-only SACL) — each asserts the expected component values are returned.
- **Runtime:** `go test ./...` passes; the pre-existing `TestSddlCut` cases (all uppercase) continue to pass, confirming no regression for the common path.

### Test Coverage
**Added:**
- `sddl/sddl_test.go::TestSddlCut_LowercaseMarkers` — three sub-tests covering lowercase and mixed-case SDDL marker forms.

### Scope of Change
- **Files changed:** `sddl/sddl.go`, `sddl/sddl_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — the fix is purely additive for previously-broken input; uppercase input parses identically.

### Risk and Rollout
Trivial change, localised to a single assignment. Any caller that previously relied on the (broken) empty-string/empty-slice return for lowercase input would be unusual; more likely, such callers were silently losing data. Safe to merge without staged rollout.