### PR TITLE
[bug] Fix SID.FromString accepting identifier authority > 48 bits (#66)

### DIFF
--- a/sid/SecurityIdentifier.go
+++ b/sid/SecurityIdentifier.go
@@ -398,10 +398,17 @@ func (sid *SID) FromString(sidString string) error {
 	}
 	sid.RevisionLevel = uint8(revision)
 
-	// Parse the identifier authority (S-<Revision>-<IdentifierAuthority>)
+	// Parse the identifier authority (S-<Revision>-<IdentifierAuthority>).
+	// The binary SID format stores this in 6 bytes (see MS-DTYP 2.4.2.1
+	// SID_IDENTIFIER_AUTHORITY), so reject values that cannot be represented
+	// rather than silently truncating them at marshal time.
 	identifierAuthority, err := strconv.ParseUint(parts[2], 10, 64)
 	if err != nil {
 		return fmt.Errorf("invalid identifier authority in SID: %v", err)
+	}
+	const maxIdentifierAuthority = uint64(1)<<48 - 1
+	if identifierAuthority > maxIdentifierAuthority {
+		return fmt.Errorf("identifier authority %d exceeds the 48-bit SID field (max %d)", identifierAuthority, maxIdentifierAuthority)
 	}
 	sid.IdentifierAuthority.Value = identifierAuthority
 

--- a/sid/SecurityIdentifier_test.go
+++ b/sid/SecurityIdentifier_test.go
@@ -331,6 +331,32 @@ func Test_SID_FromStringMarshalToString(t *testing.T) {
 	}
 }
 
+// Test_SID_FromString_IdentifierAuthorityRange verifies that FromString rejects
+// identifier-authority values that cannot fit in the 6-byte binary field, and
+// accepts values exactly at the 48-bit boundary.
+func Test_SID_FromString_IdentifierAuthorityRange(t *testing.T) {
+	cases := []struct {
+		sidString string
+		wantErr   bool
+	}{
+		{"S-1-281474976710655-0", false}, // 2^48 - 1, maximum legal value
+		{"S-1-281474976710656-0", true},  // 2^48, one beyond the 6-byte field
+		{"S-1-999999999999999-0", true},  // clearly out of range
+	}
+	for _, tc := range cases {
+		t.Run(tc.sidString, func(t *testing.T) {
+			s := &sid.SID{}
+			err := s.FromString(tc.sidString)
+			if tc.wantErr && err == nil {
+				t.Fatalf("FromString(%q) expected an error, got nil", tc.sidString)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("FromString(%q) unexpected error: %v", tc.sidString, err)
+			}
+		})
+	}
+}
+
 func Test_SID_ToString(t *testing.T) {
 	sid := &sid.SID{
 		RevisionLevel: 1,


### PR DESCRIPTION
### Linked Issue
Closes #66

### Root Cause
`SID.FromString` called `strconv.ParseUint(parts[2], 10, 64)` for the identifier-authority component and assigned the result directly into `IdentifierAuthority.Value` (a `uint64`). The SID binary layout defined by MS-DTYP 2.4.2.1 (`SID_IDENTIFIER_AUTHORITY`) only has 6 bytes for this field, and `authority/SecurityIdentifierAuthority.Marshal` writes the low 48 bits via three `uint16` casts. Any value between `2^48` and `2^64 - 1` was therefore accepted at parse time and silently truncated at marshal time, so a `FromString → Marshal → Unmarshal` round-trip produced a different SID with no error signalled.

### Fix Description
After parsing, validate that the numeric value is at most `2^48 - 1`. Return an error otherwise, with a message that states both the offending value and the limit.

### How Verified
- **Tests:** Added `Test_SID_FromString_IdentifierAuthorityRange` with three inputs — exactly `2^48 - 1` (accepted), exactly `2^48` (rejected), and `999999999999999` (rejected).
- **Runtime:** `go test ./...` passes, including the existing involution tests that exercise every well-known SID; none of them exceed the 48-bit boundary.

### Test Coverage
**Added:**
- `sid/SecurityIdentifier_test.go::Test_SID_FromString_IdentifierAuthorityRange` — asserts accept/reject behaviour at and beyond the 48-bit boundary.

### Scope of Change
- **Files changed:** `sid/SecurityIdentifier.go`, `sid/SecurityIdentifier_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — every value previously parsed that is within the 48-bit range still parses identically.

### Risk and Rollout
Narrow. Real-world SIDs never have an identifier authority above `0x12` (`Security Authentication`), so the rejected range is entirely synthetic input. Callers that happened to construct out-of-range SIDs were already silently corrupting their data via marshal truncation. Safe to merge without staged rollout.

### Notes
The sub-authority components at `SecurityIdentifier.go:411` already use `ParseUint(..., 10, 32)` and reject out-of-range values; this PR brings the identifier authority in line with that approach.