### PR TITLE
[enhancement] Add ApplicationData support for callback ACE types (#39)

### DIFF
--- a/ace/AccessControlEntry.go
+++ b/ace/AccessControlEntry.go
@@ -1,6 +1,7 @@
 package ace
 
 import (
+	"encoding/hex"
 	"fmt"
 	"strings"
 
@@ -18,6 +19,15 @@ type AccessControlEntry struct {
 	Mask                    mask.AccessControlMask
 	Identity                identity.Identity
 	AccessControlObjectType object.AccessControlObjectType
+
+	// ApplicationData holds the optional, variable-length trailing bytes of an
+	// ACE that follow the fixed fields. For callback ACE types
+	// (ACCESS_ALLOWED_CALLBACK, ACCESS_DENIED_CALLBACK and their object/audit
+	// variants) this is the conditional expression; for
+	// SYSTEM_RESOURCE_ATTRIBUTE and SYSTEM_SCOPED_POLICY_ID ACEs it is the
+	// attribute or policy data. The length is derived from the ACE Header.Size.
+	// These bytes are preserved verbatim so that Marshal(Unmarshal(x)) == x.
+	ApplicationData []byte
 
 	// Internal
 	RawBytes     []byte
@@ -546,6 +556,18 @@ func (ace *AccessControlEntry) Unmarshal(marshalledData []byte) (int, error) {
 		return 0, fmt.Errorf("unknown ACE type: %d", ace.Header.Type.Value)
 	}
 
+	// Capture any trailing bytes that follow the fixed ACE fields as
+	// ApplicationData. Callback, resource-attribute and scoped-policy ACE types
+	// carry a conditional expression or attribute/policy blob here whose size is
+	// implied by Header.Size. Preserving these bytes is required for a lossless
+	// Marshal/Unmarshal round-trip; previously they were dropped and replaced
+	// with zero padding on Marshal.
+	if ace.RawBytesSize < uint32(ace.Header.Size) {
+		ace.ApplicationData = ace.RawBytes[ace.RawBytesSize:ace.Header.Size]
+	} else {
+		ace.ApplicationData = nil
+	}
+
 	// Return the full ACE size from the header, not just the bytes we parsed.
 	// ACE types with ApplicationData (callback, resource attribute, scoped policy)
 	// have trailing data beyond what we explicitly parse, and the caller needs
@@ -770,6 +792,12 @@ func (ace *AccessControlEntry) Marshal() ([]byte, error) {
 		marshalledData = append(marshalledData, bytesStream...)
 	}
 
+	// Append any preserved ApplicationData (conditional expression for callback
+	// ACEs, attribute data for resource-attribute ACEs, policy id for
+	// scoped-policy ACEs) so it survives the round-trip instead of being lost to
+	// zero padding below.
+	marshalledData = append(marshalledData, ace.ApplicationData...)
+
 	// Pad the marshalled data to the size specified in the ACE header
 	headerSize := 4
 	if ace.Header.Size > uint16(len(marshalledData)+headerSize) {
@@ -875,6 +903,10 @@ func (ace *AccessControlEntry) Describe(indent int) {
 	case acetype.ACE_TYPE_SYSTEM_SCOPED_POLICY_ID:
 		ace.Mask.Describe(indent + 1)
 		ace.Identity.Describe(indent + 1)
+	}
+
+	if len(ace.ApplicationData) > 0 {
+		fmt.Printf("%s │ \x1b[93mApplicationData\x1b[0m : \x1b[96m%s\x1b[0m\n", indentPrompt, hex.EncodeToString(ace.ApplicationData))
 	}
 
 	fmt.Printf("%s └─\n", indentPrompt)

--- a/ace/AccessControlEntry_functions.go
+++ b/ace/AccessControlEntry_functions.go
@@ -1,6 +1,7 @@
 package ace
 
 import (
+	"bytes"
 	"slices"
 
 	"github.com/TheManticoreProject/winacl/ace/aceflags"
@@ -56,6 +57,13 @@ func (ace *AccessControlEntry) Equal(other *AccessControlEntry) bool {
 
 	// Compare ObjectType fields if present
 	if !ace.AccessControlObjectType.Equal(&other.AccessControlObjectType) {
+		return false
+	}
+
+	// Compare ApplicationData (conditional expression / attribute data carried by
+	// callback, resource-attribute and scoped-policy ACE types). bytes.Equal
+	// treats nil and empty slices as equal, which is the desired behavior here.
+	if !bytes.Equal(ace.ApplicationData, other.ApplicationData) {
 		return false
 	}
 

--- a/ace/AccessControlEntry_test.go
+++ b/ace/AccessControlEntry_test.go
@@ -116,3 +116,65 @@ func TestAccessControlEntry_Unmarshal_MalformedNoPanic(t *testing.T) {
 		})
 	}
 }
+
+// TestAccessControlEntry_Involution_ApplicationData verifies that ACE types
+// carrying variable-length trailing ApplicationData (callback ACEs and their
+// object variants, resource-attribute and scoped-policy ACEs) survive a
+// Marshal(Unmarshal(x)) round-trip without losing the trailing bytes. Before
+// ApplicationData was captured, Marshal replaced these bytes with zero padding,
+// silently corrupting the conditional expression / attribute data.
+func TestAccessControlEntry_Involution_ApplicationData(t *testing.T) {
+	const (
+		// Mask + 28-byte SID (S-1-5-21-...) reused from the other involution test.
+		body = "ff010f0001050000000000051500000028bb82279261b9fe2474aa5d00020000"
+		// A "artx" conditional-expression marker followed by some payload bytes.
+		appData = "61727478deadbeefcafe0000"
+	)
+
+	cases := []struct {
+		name string
+		hex  string
+	}{
+		// ACCESS_ALLOWED_CALLBACK (0x09): header + mask + sid + ApplicationData.
+		// Size = 4 + 4 + 28 + 12 = 48 = 0x30.
+		{"access_allowed_callback", "09003000" + body + appData},
+		// ACCESS_DENIED_CALLBACK (0x0a).
+		{"access_denied_callback", "0a003000" + body + appData},
+		// ACCESS_ALLOWED_CALLBACK_OBJECT (0x0b) with an object-type Flags field of
+		// 0 (no GUIDs present): header + mask + flags(4) + sid + ApplicationData.
+		// Size = 4 + 4 + 4 + 28 + 12 = 52 = 0x34.
+		{"access_allowed_callback_object", "0b003400ff010f0000000000" +
+			"01050000000000051500000028bb82279261b9fe2474aa5d00020000" + appData},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rawBytes, err := hex.DecodeString(tc.hex)
+			if err != nil {
+				t.Fatalf("Failed to decode hex string: %v", err)
+			}
+
+			var ace AccessControlEntry
+			_, err = ace.Unmarshal(rawBytes)
+			if err != nil {
+				t.Fatalf("Failed to unmarshal AccessControlEntry: %v", err)
+			}
+
+			expectedAppData, _ := hex.DecodeString(appData)
+			if !bytes.Equal(ace.ApplicationData, expectedAppData) {
+				t.Fatalf("ApplicationData mismatch: expected %s, got %s",
+					appData, hex.EncodeToString(ace.ApplicationData))
+			}
+
+			serializedBytes, err := ace.Marshal()
+			if err != nil {
+				t.Fatalf("Failed to marshal AccessControlEntry: %v", err)
+			}
+
+			if !bytes.Equal(rawBytes, serializedBytes) {
+				t.Errorf("Involution test failed: expected %s, got %s",
+					hex.EncodeToString(rawBytes), hex.EncodeToString(serializedBytes))
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #39`

### Motivation
`ACCESS_ALLOWED_CALLBACK_ACE_TYPE` / `ACCESS_DENIED_CALLBACK_ACE_TYPE` ACEs (and their object, resource-attribute, and scoped-policy siblings) carry a variable-length trailing blob — the conditional expression or attribute/policy data — whose length is implied by `Header.Size`. A concrete consumer is the security descriptor at `HKLM:\SYSTEM\CurrentControlSet\Services\CertSvc\Configuration\<CANAME>\EnrollmentAgentRights` on ADCS servers, where this data identifies the templates affected by each restriction. The parser previously discarded these bytes: `Unmarshal` skipped them and `Marshal` replaced them with zero padding, so any round-trip silently corrupted the ACE.

### What Changed
- Added a new exported field `AccessControlEntry.ApplicationData []byte`.
- `Unmarshal` now captures the bytes between the end of the parsed fixed fields (`RawBytesSize`) and the ACE size declared in the header (`Header.Size`) into `ApplicationData`. This is generic across all ACE types, so any trailing data is preserved.
- `Marshal` now appends `ApplicationData` to the body before the size/padding logic, so the conditional expression / attribute data survives the round-trip instead of being lost to zero padding.
- `Equal` now compares `ApplicationData` (using `bytes.Equal`, which treats nil and empty as equal).
- `Describe` prints the `ApplicationData` as hex when present.

### Design Notes
The capture is intentionally generic (trailing bytes between parsed fields and `Header.Size`) rather than per-type. This preserves data losslessly for every ACE type without enumerating each one, and is a no-op for ACE types whose fields already consume the full declared size (`ApplicationData` is then empty/nil).

### Acceptance Criteria Check
- Callback ACEs preserve their conditional-expression bytes across `Marshal(Unmarshal(x))`: verified by `TestAccessControlEntry_Involution_ApplicationData` (subcases `access_allowed_callback`, `access_denied_callback`, `access_allowed_callback_object`).
- The trailing bytes are accessible to consumers: exposed via the public `ApplicationData` field, asserted in the same test.

### How Verified
- **Tests:** `go test ./...` passes. New test `TestAccessControlEntry_Involution_ApplicationData` unmarshals callback ACEs with a trailing `artx`-prefixed blob, asserts `ApplicationData` matches the input bytes, and asserts the marshalled output is byte-identical to the input.
- Existing involution test `TestAccessControlEntry_Involution_ACE_TYPE_ACCESS_ALLOWED` continues to pass (no regression for non-callback ACEs).

### Test Coverage
- **Added:** `ace/AccessControlEntry_test.go` — `TestAccessControlEntry_Involution_ApplicationData`.

### Scope of Change
- **Files changed:** `ace/AccessControlEntry.go`, `ace/AccessControlEntry_functions.go`, `ace/AccessControlEntry_test.go`
- **Submodule pointer updated:** no
- **Public API changes:** additive — new `AccessControlEntry.ApplicationData` field; no existing field or signature changed.
- **Behavioral changes outside the stated enhancement:** none

### Risk and Rollout
Low blast radius. The capture is additive and a no-op for ACE types that have no trailing data. The only behavioral change is that previously-discarded trailing bytes are now retained and re-emitted, which strictly improves round-trip fidelity.

### Notes
The Marshal switch is missing cases for `ACCESS_DENIED_CALLBACK_OBJECT` (0x0c) and `SYSTEM_AUDIT_CALLBACK` (0x0d), which causes their Mask/ObjectType/Identity to be dropped on Marshal. That is a separate defect and is filed/fixed independently to keep this PR focused.
