### PR TITLE
[bug] Fix Marshal dropping fields for callback-object and audit-callback ACEs (#70)

### DIFF
--- a/ace/AccessControlEntry.go
+++ b/ace/AccessControlEntry.go
@@ -731,6 +731,38 @@ func (ace *AccessControlEntry) Marshal() ([]byte, error) {
 		}
 		marshalledData = append(marshalledData, bytesStream...)
 
+	case acetype.ACE_TYPE_ACCESS_DENIED_CALLBACK_OBJECT:
+		bytesStream, err = ace.Mask.Marshal()
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal Mask: %w", err)
+		}
+		marshalledData = append(marshalledData, bytesStream...)
+
+		bytesStream, err = ace.AccessControlObjectType.Marshal()
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal AccessControlObjectType: %w", err)
+		}
+		marshalledData = append(marshalledData, bytesStream...)
+
+		bytesStream, err = ace.Identity.Marshal()
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal Identity: %w", err)
+		}
+		marshalledData = append(marshalledData, bytesStream...)
+
+	case acetype.ACE_TYPE_SYSTEM_AUDIT_CALLBACK:
+		bytesStream, err = ace.Mask.Marshal()
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal Mask: %w", err)
+		}
+		marshalledData = append(marshalledData, bytesStream...)
+
+		bytesStream, err = ace.Identity.Marshal()
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal Identity: %w", err)
+		}
+		marshalledData = append(marshalledData, bytesStream...)
+
 	case acetype.ACE_TYPE_SYSTEM_ALARM_CALLBACK:
 	case acetype.ACE_TYPE_SYSTEM_AUDIT_CALLBACK_OBJECT:
 		bytesStream, err = ace.Mask.Marshal()

--- a/ace/AccessControlEntry_test.go
+++ b/ace/AccessControlEntry_test.go
@@ -178,3 +178,48 @@ func TestAccessControlEntry_Involution_ApplicationData(t *testing.T) {
 		})
 	}
 }
+
+// TestAccessControlEntry_Involution_CallbackObjectAndAuditCallback is a
+// regression test for the Marshal switch omitting the
+// ACCESS_DENIED_CALLBACK_OBJECT (0x0c) and SYSTEM_AUDIT_CALLBACK (0x0d) ACE
+// types. Before the fix, Marshal emitted only the 4-byte header (plus zero
+// padding) for these types, silently dropping the Mask, ObjectType and SID.
+func TestAccessControlEntry_Involution_CallbackObjectAndAuditCallback(t *testing.T) {
+	const sid28 = "01050000000000051500000028bb82279261b9fe2474aa5d00020000"
+
+	cases := []struct {
+		name string
+		hex  string
+	}{
+		// ACCESS_DENIED_CALLBACK_OBJECT (0x0c) with object-type Flags = 0 (no
+		// GUIDs): header + mask + flags(4) + sid. Size = 4 + 4 + 4 + 28 = 40 = 0x28.
+		{"access_denied_callback_object", "0c002800ff010f0000000000" + sid28},
+		// SYSTEM_AUDIT_CALLBACK (0x0d): header + mask + sid. Size = 4 + 4 + 28 = 36 = 0x24.
+		{"system_audit_callback", "0d002400ff010f00" + sid28},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			rawBytes, err := hex.DecodeString(tc.hex)
+			if err != nil {
+				t.Fatalf("Failed to decode hex string: %v", err)
+			}
+
+			var ace AccessControlEntry
+			_, err = ace.Unmarshal(rawBytes)
+			if err != nil {
+				t.Fatalf("Failed to unmarshal AccessControlEntry: %v", err)
+			}
+
+			serializedBytes, err := ace.Marshal()
+			if err != nil {
+				t.Fatalf("Failed to marshal AccessControlEntry: %v", err)
+			}
+
+			if !bytes.Equal(rawBytes, serializedBytes) {
+				t.Errorf("Involution test failed: expected %s, got %s",
+					hex.EncodeToString(rawBytes), hex.EncodeToString(serializedBytes))
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #70`

### Root Cause
`(*AccessControlEntry).Marshal()` dispatches on `ace.Header.Type.Value` with one `case` per ACE type, but two values were never added: `ACCESS_DENIED_CALLBACK_OBJECT` (0x0c) and `SYSTEM_AUDIT_CALLBACK` (0x0d). Both are fully handled in `Unmarshal` (and `Describe`), so an ACE of either type parses correctly but, on Marshal, falls through the switch with an empty body. The trailing padding logic then sets `Header.Size` to just the 4-byte header, discarding the Mask, ObjectType, and SID.

### Fix Description
Added the two missing `case` labels, mirroring the field layout used by `Unmarshal` and by the analogous existing Marshal cases:
- `ACCESS_DENIED_CALLBACK_OBJECT` (0x0c): marshals Mask + AccessControlObjectType + Identity (same as `ACCESS_ALLOWED_CALLBACK_OBJECT`).
- `SYSTEM_AUDIT_CALLBACK` (0x0d): marshals Mask + Identity (same as `ACCESS_ALLOWED_CALLBACK`).

### How Verified
- **Tests:** new `TestAccessControlEntry_Involution_CallbackObjectAndAuditCallback` unmarshals a 0x0c ACE (Mask + object-type Flags + SID) and a 0x0d ACE (Mask + SID), marshals them, and asserts the output is byte-identical to the input. Before the fix the marshalled output was just the header plus zero padding, so the assertion failed; after the fix both subcases pass.
- `go test ./...` passes.

### Test Coverage
- **Added:** `ace/AccessControlEntry_test.go` — `TestAccessControlEntry_Involution_CallbackObjectAndAuditCallback`.

### Scope of Change
- **Files changed:** `ace/AccessControlEntry.go`, `ace/AccessControlEntry_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Low risk and local. The change only adds serialization for two ACE types that previously produced corrupt output; no other type's path is touched. Safe to merge without staged rollout.

### Notes
Related enhancement #39 / PR #69 adds preservation of trailing `ApplicationData` for callback ACE types; this PR is independent and intentionally uses ACEs without trailing data so the round-trip is exercised by the field-serialization fix alone.
