### PR TITLE
[enhancement] Fix SID.Unmarshal silently zero-padding a truncated RelativeIdentifier (#72)

### DIFF
--- a/sid/SecurityIdentifier.go
+++ b/sid/SecurityIdentifier.go
@@ -308,17 +308,18 @@ func (sid *SID) Unmarshal(marshalledData []byte) (int, error) {
 		}
 	}
 
-	if int(sid.RawBytesSize) < len(marshalledData) {
-		// Here we pad the relative identifier bytes to match the expected length of 4 bytes
-		remaining := marshalledData[sid.RawBytesSize:]
-		actualLen := len(remaining)
-		if actualLen > 4 {
-			actualLen = 4
+	// Parse the RelativeIdentifier (the last sub-authority). Per MS-DTYP 2.4.2 a
+	// SID with SubAuthorityCount > 0 always carries a full 4-byte final
+	// sub-authority, so require those 4 bytes rather than silently zero-padding a
+	// truncated value, which would fabricate a valid-looking SID from malformed
+	// input and report a wrong consumed-byte count.
+	if sid.SubAuthorityCount > 0 {
+		if len(marshalledData) >= int(sid.RawBytesSize)+4 {
+			sid.RelativeIdentifier = binary.LittleEndian.Uint32(marshalledData[sid.RawBytesSize : sid.RawBytesSize+4])
+			sid.RawBytesSize += 4
+		} else {
+			return 0, fmt.Errorf("not enough data to parse RelativeIdentifier")
 		}
-		buffer := make([]byte, 4)
-		copy(buffer, remaining[:actualLen])
-		sid.RelativeIdentifier = binary.LittleEndian.Uint32(buffer)
-		sid.RawBytesSize += uint32(actualLen)
 	}
 
 	return int(sid.RawBytesSize), nil

--- a/sid/SecurityIdentifier_test.go
+++ b/sid/SecurityIdentifier_test.go
@@ -405,6 +405,34 @@ func Test_SID_Marshal_ZeroRID(t *testing.T) {
 	}
 }
 
+// Test_SID_Unmarshal_TruncatedRID verifies that Unmarshal rejects input whose
+// declared SubAuthorityCount mandates a RelativeIdentifier that is missing or
+// truncated, instead of silently zero-padding it and returning success.
+func Test_SID_Unmarshal_TruncatedRID(t *testing.T) {
+	testCases := []struct {
+		name string
+		hex  string
+	}{
+		// rev=1, SAC=2, auth=5, one sub-authority (0x15=21), RID entirely absent.
+		{name: "RID missing", hex: "0102000000000005" + "15000000"},
+		// Same header, RID truncated to 2 of 4 bytes.
+		{name: "RID truncated to 2 bytes", hex: "0102000000000005" + "15000000" + "f401"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			raw, err := hex.DecodeString(tc.hex)
+			if err != nil {
+				t.Fatalf("invalid test hex: %v", err)
+			}
+			s := &sid.SID{}
+			if _, err := s.Unmarshal(raw); err == nil {
+				t.Errorf("Unmarshal(%s) = nil error, want error on truncated RID", tc.hex)
+			}
+		})
+	}
+}
+
 // Test_SID_UnmarshalMarshal_ZeroRID verifies that parsing a genuine 12-byte
 // binary for a zero-RID SID and re-marshalling preserves the exact bytes.
 func Test_SID_UnmarshalMarshal_ZeroRID(t *testing.T) {


### PR DESCRIPTION
### Linked Issue
`Closes #72`

### Root Cause
`SID.Unmarshal` parsed the RelativeIdentifier (the final sub-authority) based on whether *any* bytes remained in the buffer rather than on the `SubAuthorityCount` declared in the SID header. When fewer than 4 bytes were present it copied what existed into a 4-byte zero buffer and read that as the RID, then returned success. The header's `SubAuthorityCount`, which per MS-DTYP 2.4.2 mandates a full 4-byte final sub-authority, was never used to validate that the RID was actually present and complete.

### Fix Description
RID parsing is now gated on `SubAuthorityCount > 0` and requires a full 4 bytes (`len(marshalledData) >= RawBytesSize+4`), returning `"not enough data to parse RelativeIdentifier"` otherwise — mirroring the existing length checks for RevisionLevel, SubAuthorityCount, IdentifierAuthority, and the loop sub-authorities. The previous cap-and-pad logic is removed. This also fixes the consumed-byte count, which previously could be reported short.

The exact-4-byte read means a `SubAuthorityCount > 0` SID followed by unrelated trailing bytes consumes exactly its own length (8 + 4*SubAuthorityCount), matching `Marshal` and the MS-DTYP layout.

### How Verified
- **Tests:** added `Test_SID_Unmarshal_TruncatedRID` in `sid/SecurityIdentifier_test.go`, covering a SID whose header declares a RID that is (a) entirely absent and (b) truncated to 2 of 4 bytes; both now return an error.
- **Existing:** `Test_SID_UnmarshalMarshal_ZeroRID` (genuine 12-byte `S-1-1-0`), `Test_SID_Involution`, and the MS-DTYP `8 + 4*SubAuthorityCount` marshal test continue to pass — full-length SIDs are unaffected.
- `go build ./...` and `go test ./...` pass.

### Test Coverage
- **Added:** `sid/SecurityIdentifier_test.go` -> `Test_SID_Unmarshal_TruncatedRID`.

### Scope of Change
- **Files changed:** `sid/SecurityIdentifier.go`, `sid/SecurityIdentifier_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Low blast radius. The change is stricter on malformed input only; well-formed SIDs (the only ones produced by `Marshal`/`FromString`) parse identically. Safe to merge directly.