### PR TITLE
[bug] Fix RawBytesSize accumulating across Marshal calls in object types (#73)

### DIFF
--- a/object/InheritedObjectType.go
+++ b/object/InheritedObjectType.go
@@ -53,7 +53,7 @@ func (inheritedObjType *InheritedObjectType) Marshal() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	inheritedObjType.RawBytesSize += uint32(len(bytesStream))
+	inheritedObjType.RawBytesSize = uint32(len(bytesStream))
 	return bytesStream, nil
 }
 

--- a/object/ObjectType.go
+++ b/object/ObjectType.go
@@ -48,7 +48,7 @@ func (objType *ObjectType) Marshal() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	objType.RawBytesSize += uint32(len(bytesStream))
+	objType.RawBytesSize = uint32(len(bytesStream))
 	return bytesStream, nil
 }
 

--- a/object/ObjectType_test.go
+++ b/object/ObjectType_test.go
@@ -1,0 +1,57 @@
+package object
+
+import (
+	"encoding/hex"
+	"testing"
+)
+
+// guidHex is the 16-byte binary representation of an arbitrary GUID used to
+// exercise the (Inherited)ObjectType marshalling helpers.
+const guidHex = "be3b0ef3f09fd111b6030000f80367c1"
+
+// Test_ObjectType_Marshal_RawBytesSize_Idempotent verifies that repeated
+// Marshal calls report the serialized size (16 bytes for a GUID) rather than
+// accumulating it.
+func Test_ObjectType_Marshal_RawBytesSize_Idempotent(t *testing.T) {
+	raw, err := hex.DecodeString(guidHex)
+	if err != nil {
+		t.Fatalf("invalid test hex: %v", err)
+	}
+
+	var ot ObjectType
+	if _, err := ot.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+
+	for i := 0; i < 3; i++ {
+		if _, err := ot.Marshal(); err != nil {
+			t.Fatalf("Marshal() call %d error = %v", i, err)
+		}
+		if ot.RawBytesSize != uint32(len(raw)) {
+			t.Errorf("after Marshal() call %d: RawBytesSize = %d, want %d", i, ot.RawBytesSize, len(raw))
+		}
+	}
+}
+
+// Test_InheritedObjectType_Marshal_RawBytesSize_Idempotent verifies the same
+// invariant for InheritedObjectType.
+func Test_InheritedObjectType_Marshal_RawBytesSize_Idempotent(t *testing.T) {
+	raw, err := hex.DecodeString(guidHex)
+	if err != nil {
+		t.Fatalf("invalid test hex: %v", err)
+	}
+
+	var iot InheritedObjectType
+	if _, err := iot.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+
+	for i := 0; i < 3; i++ {
+		if _, err := iot.Marshal(); err != nil {
+			t.Fatalf("Marshal() call %d error = %v", i, err)
+		}
+		if iot.RawBytesSize != uint32(len(raw)) {
+			t.Errorf("after Marshal() call %d: RawBytesSize = %d, want %d", i, iot.RawBytesSize, len(raw))
+		}
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #73`

### Root Cause
`ObjectType.Marshal` and `InheritedObjectType.Marshal` updated the public `RawBytesSize` field with `+=` and never reset it to 0 at entry. Because the field already held a value from a prior `Unmarshal`/`Marshal`, every subsequent `Marshal` added the GUID length (16) again, so the reported size grew without bound (16 -> 32 -> 48 ...). The matching `Unmarshal` methods reset the field to 0 first, so the two directions disagreed.

### Fix Description
Both `Marshal` methods now assign the serialized length (`RawBytesSize = uint32(len(bytesStream))`) instead of accumulating it, making the field reflect the actual byte count produced on every call. This is the minimal change and mirrors the intent of the assignment in `Unmarshal`.

### How Verified
- **Tests:** added `object/ObjectType_test.go` with `Test_ObjectType_Marshal_RawBytesSize_Idempotent` and `Test_InheritedObjectType_Marshal_RawBytesSize_Idempotent`, which Unmarshal a GUID then call Marshal three times, asserting `RawBytesSize == 16` after each call. Both fail before the fix and pass after.
- `go build ./...` and `go test ./...` pass.

### Test Coverage
- **Added:** `object/ObjectType_test.go` -> `Test_ObjectType_Marshal_RawBytesSize_Idempotent`, `Test_InheritedObjectType_Marshal_RawBytesSize_Idempotent`.

### Scope of Change
- **Files changed:** `object/ObjectType.go`, `object/InheritedObjectType.go`, `object/ObjectType_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Trivial and local; the returned byte slice is unchanged, only the bookkeeping field is corrected. Safe to merge directly.