### PR TITLE
[bug] Fix RawBytesSize accumulating across Marshal calls in ACL headers (#74)

### DIFF
--- a/acl/DiscretionaryAccessControlListHeader.go
+++ b/acl/DiscretionaryAccessControlListHeader.go
@@ -66,6 +66,8 @@ func (daclheader *DiscretionaryAccessControlListHeader) Unmarshal(marshalledData
 func (daclheader *DiscretionaryAccessControlListHeader) Marshal() ([]byte, error) {
 	var marshalledData []byte
 
+	daclheader.RawBytesSize = 0
+
 	bytesStream, err := daclheader.Revision.Marshal()
 	if err != nil {
 		return nil, err

--- a/acl/DiscretionaryAccessControlListHeader_test.go
+++ b/acl/DiscretionaryAccessControlListHeader_test.go
@@ -75,3 +75,27 @@ func TestDiscretionaryAccessControlListHeader_Involution(t *testing.T) {
 		t.Errorf("Sbz2 value not preserved: expected %d, got %d", daclHeader.Sbz2, daclHeader2.Sbz2)
 	}
 }
+
+// TestDiscretionaryAccessControlListHeader_Marshal_RawBytesSize_Idempotent
+// verifies that repeated Marshal calls report the fixed 8-byte header size
+// rather than accumulating it.
+func TestDiscretionaryAccessControlListHeader_Marshal_RawBytesSize_Idempotent(t *testing.T) {
+	daclHeaderBytes, err := hex.DecodeString("0100140002000000")
+	if err != nil {
+		t.Fatalf("Failed to decode header hex: %v", err)
+	}
+
+	daclHeader := &DiscretionaryAccessControlListHeader{}
+	if _, err := daclHeader.Unmarshal(daclHeaderBytes); err != nil {
+		t.Fatalf("Failed to unmarshal DACL header: %v", err)
+	}
+
+	for i := 0; i < 3; i++ {
+		if _, err := daclHeader.Marshal(); err != nil {
+			t.Fatalf("Marshal() call %d error = %v", i, err)
+		}
+		if daclHeader.RawBytesSize != 8 {
+			t.Errorf("after Marshal() call %d: RawBytesSize = %d, want 8", i, daclHeader.RawBytesSize)
+		}
+	}
+}

--- a/acl/SystemAccessControlListHeader.go
+++ b/acl/SystemAccessControlListHeader.go
@@ -65,6 +65,8 @@ func (saclheader *SystemAccessControlListHeader) Unmarshal(marshalledData []byte
 func (saclheader *SystemAccessControlListHeader) Marshal() ([]byte, error) {
 	var marshalledData []byte
 
+	saclheader.RawBytesSize = 0
+
 	bytesStream, err := saclheader.Revision.Marshal()
 	if err != nil {
 		return nil, fmt.Errorf("failed to marshal Revision: %w", err)

--- a/acl/SystemAccessControlListHeader_test.go
+++ b/acl/SystemAccessControlListHeader_test.go
@@ -63,6 +63,28 @@ func TestSystemAccessControlListHeader_MarshalUnmarshal(t *testing.T) {
 	}
 }
 
+// TestSystemAccessControlListHeader_Marshal_RawBytesSize_Idempotent verifies
+// that repeated Marshal calls report the fixed 8-byte header size rather than
+// accumulating it.
+func TestSystemAccessControlListHeader_Marshal_RawBytesSize_Idempotent(t *testing.T) {
+	header := SystemAccessControlListHeader{
+		Revision: revision.AccessControlListRevision{Value: 0x02},
+		Sbz1:     0x00,
+		AclSize:  0x30,
+		AceCount: 0x05,
+		Sbz2:     0x00,
+	}
+
+	for i := 0; i < 3; i++ {
+		if _, err := header.Marshal(); err != nil {
+			t.Fatalf("Marshal() call %d error = %v", i, err)
+		}
+		if header.RawBytesSize != 8 {
+			t.Errorf("after Marshal() call %d: RawBytesSize = %d, want 8", i, header.RawBytesSize)
+		}
+	}
+}
+
 func TestSystemAccessControlListHeader_MarshalUnmarshalWithEdgeCases(t *testing.T) {
 	testCases := []struct {
 		name     string


### PR DESCRIPTION
### Linked Issue
`Closes #74`

### Root Cause
`SystemAccessControlListHeader.Marshal` and `DiscretionaryAccessControlListHeader.Marshal` build up the public `RawBytesSize` field with a series of `+=` operations (1+1+2+2+2 = 8) but never reset it to 0 at the start. With a value left over from a prior `Unmarshal`/`Marshal`, each subsequent `Marshal` added another 8 (8 -> 16 -> 24 ...). The matching `Unmarshal` methods reset the field to 0 first, so the two directions disagreed.

### Fix Description
Each `Marshal` now sets `RawBytesSize = 0` at entry, before the `+=` accumulation, mirroring the corresponding `Unmarshal`. The serialized byte slice is unchanged; only the tracked size field is corrected so it always reports 8 regardless of call count.

### How Verified
- **Tests:** added `TestDiscretionaryAccessControlListHeader_Marshal_RawBytesSize_Idempotent` and `TestSystemAccessControlListHeader_Marshal_RawBytesSize_Idempotent`, which call Marshal three times and assert `RawBytesSize == 8` after each. Both fail before the fix and pass after.
- `go build ./...` and `go test ./...` pass.

### Test Coverage
- **Added:** `acl/DiscretionaryAccessControlListHeader_test.go` -> `TestDiscretionaryAccessControlListHeader_Marshal_RawBytesSize_Idempotent`; `acl/SystemAccessControlListHeader_test.go` -> `TestSystemAccessControlListHeader_Marshal_RawBytesSize_Idempotent`.

### Scope of Change
- **Files changed:** `acl/SystemAccessControlListHeader.go`, `acl/DiscretionaryAccessControlListHeader.go`, `acl/SystemAccessControlListHeader_test.go`, `acl/DiscretionaryAccessControlListHeader_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Trivial and local; output bytes are unaffected and only the bookkeeping field is corrected. Safe to merge directly.