### PR TITLE
Bound SACL/DACL Unmarshal by AclSize to prevent over-reading adjacent components (#78)

### DIFF
--- a/acl/DiscretionaryAccessControlList.go
+++ b/acl/DiscretionaryAccessControlList.go
@@ -33,17 +33,30 @@ func (dacl *DiscretionaryAccessControlList) Unmarshal(marshalledData []byte) (in
 	dacl.RawBytesSize += uint32(rawBytesSize)
 	marshalledData = marshalledData[rawBytesSize:]
 
+	// Bound ACE parsing to the region declared by AclSize. The caller hands in
+	// the entire remaining buffer (in a security descriptor the ACL is followed
+	// by the Owner/Group SIDs), so without this bound a corrupt or oversized
+	// AceCount would walk past the ACL and mis-parse adjacent components as ACEs.
+	if int(dacl.Header.AclSize) < rawBytesSize {
+		return 0, fmt.Errorf("invalid DACL: AclSize (%d) is smaller than the header size (%d)", dacl.Header.AclSize, rawBytesSize)
+	}
+	aceRegionLen := int(dacl.Header.AclSize) - rawBytesSize
+	if aceRegionLen > len(marshalledData) {
+		return 0, fmt.Errorf("invalid DACL: AclSize (%d) exceeds available data (%d)", dacl.Header.AclSize, rawBytesSize+len(marshalledData))
+	}
+	aceData := marshalledData[:aceRegionLen]
+
 	// Parse all ACEs
 	for index := 0; index < int(dacl.Header.AceCount); index++ {
 		entry := ace.AccessControlEntry{}
-		rawBytesSize, err := entry.Unmarshal(marshalledData)
+		rawBytesSize, err := entry.Unmarshal(aceData)
 		if err != nil {
-			return 0, err
+			return 0, fmt.Errorf("failed to unmarshal ACE %d/%d within AclSize: %w", index+1, dacl.Header.AceCount, err)
 		}
 		entry.Index = uint16(index + 1)
 		dacl.Entries = append(dacl.Entries, entry)
 		dacl.RawBytesSize += uint32(rawBytesSize)
-		marshalledData = marshalledData[rawBytesSize:]
+		aceData = aceData[rawBytesSize:]
 	}
 
 	dacl.RawBytes = dacl.RawBytes[:dacl.RawBytesSize]

--- a/acl/DiscretionaryAccessControlList_aclsize_test.go
+++ b/acl/DiscretionaryAccessControlList_aclsize_test.go
@@ -1,0 +1,77 @@
+package acl_test
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/winacl/ace"
+	"github.com/TheManticoreProject/winacl/ace/acetype"
+	"github.com/TheManticoreProject/winacl/acl"
+	"github.com/TheManticoreProject/winacl/acl/revision"
+)
+
+// buildSingleEntryDACL returns the marshalled bytes of a DACL containing exactly
+// one ACCESS_ALLOWED ACE, along with the marshalled length.
+func buildSingleEntryDACL(t *testing.T) []byte {
+	t.Helper()
+
+	dacl := &acl.DiscretionaryAccessControlList{}
+	dacl.Header.Revision.SetRevision(revision.ACL_REVISION_DS)
+
+	entry := ace.AccessControlEntry{}
+	entry.Header.Type.Value = acetype.ACE_TYPE_ACCESS_ALLOWED
+	entry.Mask.SetRights([]uint32{0x00000001})
+	entry.Identity.SID.FromString("S-1-1-0")
+	dacl.AddEntry(entry)
+
+	data, err := dacl.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	return data
+}
+
+// TestDACL_Unmarshal_TrailingBytesNotConsumed verifies that Unmarshal stops at
+// AclSize and does not read trailing bytes (e.g. the Owner/Group SIDs that
+// follow the ACL inside a security descriptor).
+func TestDACL_Unmarshal_TrailingBytesNotConsumed(t *testing.T) {
+	good := buildSingleEntryDACL(t)
+
+	// Simulate the ACL being followed by other descriptor components.
+	withTrailing := append(append([]byte{}, good...), 0xDE, 0xAD, 0xBE, 0xEF)
+
+	dacl := &acl.DiscretionaryAccessControlList{}
+	consumed, err := dacl.Unmarshal(withTrailing)
+	if err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+
+	if consumed != len(good) {
+		t.Errorf("Unmarshal() consumed = %d, want %d (AclSize, trailing bytes excluded)", consumed, len(good))
+	}
+	if consumed != int(dacl.Header.AclSize) {
+		t.Errorf("Unmarshal() consumed = %d, want AclSize = %d", consumed, dacl.Header.AclSize)
+	}
+	if len(dacl.Entries) != 1 {
+		t.Errorf("Unmarshal() parsed %d entries, want 1", len(dacl.Entries))
+	}
+}
+
+// TestDACL_Unmarshal_AceCountExceedsAclSize verifies that an AceCount which
+// overstates the ACEs that fit within AclSize is rejected instead of reading
+// past the ACL.
+func TestDACL_Unmarshal_AceCountExceedsAclSize(t *testing.T) {
+	good := buildSingleEntryDACL(t)
+
+	// The DACL header is 8 bytes; AceCount is the little-endian uint16 at offset
+	// 4. Bump it from 1 to 2 without changing AclSize, then append bytes that
+	// look like they could be another ACE so the over-read would otherwise have
+	// data to consume.
+	corrupt := append(append([]byte{}, good...), make([]byte, 32)...)
+	corrupt[4] = 0x02
+	corrupt[5] = 0x00
+
+	dacl := &acl.DiscretionaryAccessControlList{}
+	if _, err := dacl.Unmarshal(corrupt); err == nil {
+		t.Error("Unmarshal() = nil error, want error when AceCount exceeds AclSize")
+	}
+}

--- a/acl/SystemAccessControlList.go
+++ b/acl/SystemAccessControlList.go
@@ -34,17 +34,30 @@ func (sacl *SystemAccessControlList) Unmarshal(marshalledData []byte) (int, erro
 	sacl.RawBytesSize += uint32(rawBytesSize)
 	marshalledData = marshalledData[rawBytesSize:]
 
+	// Bound ACE parsing to the region declared by AclSize. The caller hands in
+	// the entire remaining buffer (in a security descriptor the ACL is followed
+	// by the Owner/Group SIDs), so without this bound a corrupt or oversized
+	// AceCount would walk past the ACL and mis-parse adjacent components as ACEs.
+	if int(sacl.Header.AclSize) < rawBytesSize {
+		return 0, fmt.Errorf("invalid SACL: AclSize (%d) is smaller than the header size (%d)", sacl.Header.AclSize, rawBytesSize)
+	}
+	aceRegionLen := int(sacl.Header.AclSize) - rawBytesSize
+	if aceRegionLen > len(marshalledData) {
+		return 0, fmt.Errorf("invalid SACL: AclSize (%d) exceeds available data (%d)", sacl.Header.AclSize, rawBytesSize+len(marshalledData))
+	}
+	aceData := marshalledData[:aceRegionLen]
+
 	// Unmarshal all ACEs
 	for index := 0; index < int(sacl.Header.AceCount); index++ {
 		entry := ace.AccessControlEntry{}
-		rawBytesSize, err := entry.Unmarshal(marshalledData)
+		rawBytesSize, err := entry.Unmarshal(aceData)
 		if err != nil {
-			return 0, err
+			return 0, fmt.Errorf("failed to unmarshal ACE %d/%d within AclSize: %w", index+1, sacl.Header.AceCount, err)
 		}
 		entry.Index = uint16(index + 1)
 		sacl.Entries = append(sacl.Entries, entry)
 		sacl.RawBytesSize += uint32(rawBytesSize)
-		marshalledData = marshalledData[rawBytesSize:]
+		aceData = aceData[rawBytesSize:]
 	}
 
 	sacl.RawBytes = sacl.RawBytes[:sacl.RawBytesSize]


### PR DESCRIPTION
### Linked Issue
`Closes #78`

### Motivation
`AccessControlList.Unmarshal` is handed the entire remaining buffer of a security descriptor — in a real descriptor the ACL is followed by the Owner and Group SIDs. The ACE loop was bounded only by `Header.AceCount`, and each `AccessControlEntry.Unmarshal` only checked its size against that whole tail. A corrupt or oversized `AceCount` therefore walked past the ACL and mis-parsed the following SID bytes as ACEs. Parsing must be confined to the region the header declares via `AclSize`.

### What Changed
- `DiscretionaryAccessControlList.Unmarshal` and `SystemAccessControlList.Unmarshal` now compute the ACE region as `AclSize - headerSize` and slice the working buffer to exactly that region (`aceData`) before the loop.
- Added two validations: `AclSize` smaller than the header size, and `AclSize` claiming more bytes than are available, each return a descriptive error.
- ACE parsing reads from the bounded `aceData`; if `AceCount` cannot be satisfied within `AclSize`, the per-ACE `Unmarshal` now fails and the error is wrapped with the ACE index.

### Design Notes
For well-formed input `AclSize == headerSize + sum(ACE sizes)`, so the accumulated `RawBytesSize` (and the returned consumed count) is unchanged — the real-dataset involution test confirms byte-for-byte round-trips still hold. The bound only changes behavior for malformed input, turning a silent over-read into an error.

### Acceptance Criteria Check
- [x] AceCount exceeding what fits in AclSize returns an error — `TestDACL_Unmarshal_AceCountExceedsAclSize`.
- [x] Well-formed ACL followed by trailing bytes parses the same ACEs; consumed size equals AclSize — `TestDACL_Unmarshal_TrailingBytesNotConsumed`.
- [x] New test constructs an ACL with trailing non-ACE bytes and asserts the parser does not read past AclSize — same test (consumed == AclSize, trailing `DEADBEEF` not consumed).
- [x] Existing ACL/SecurityDescriptor round-trip tests pass — `go test ./...` green, including `TestNtSecurityDescriptor_Involution` over the real Windows/AD datasets.

### How Verified
- **Tests:** `acl/DiscretionaryAccessControlList_aclsize_test.go` — `TestDACL_Unmarshal_TrailingBytesNotConsumed`, `TestDACL_Unmarshal_AceCountExceedsAclSize`.
- `go build ./...` and `go test ./...` pass.

### Test Coverage
- **Added:** the two tests above, exercising both ACL types through the shared change.

### Scope of Change
- **Files changed:** `acl/DiscretionaryAccessControlList.go`, `acl/SystemAccessControlList.go`, `acl/DiscretionaryAccessControlList_aclsize_test.go`
- **Submodule pointer updated:** no
- **Public API changes:** none (signatures unchanged; `Unmarshal` may now return an error on malformed input it previously mis-parsed)
- **Behavioral changes outside the stated enhancement:** none

### Risk and Rollout
Low. Well-formed descriptors are unaffected (verified against the dataset involution test); only malformed/oversized ACLs now error instead of silently over-reading. Safe to merge.