### PR TITLE
Guard against uint16 overflow when marshalling oversized ACLs and ACEs (#79)

### DIFF
--- a/ace/AccessControlEntry.go
+++ b/ace/AccessControlEntry.go
@@ -832,13 +832,21 @@ func (ace *AccessControlEntry) Marshal() ([]byte, error) {
 
 	// Pad the marshalled data to the size specified in the ACE header
 	headerSize := 4
-	if ace.Header.Size > uint16(len(marshalledData)+headerSize) {
+	// The ACE Header.Size field is a uint16, so the body plus the 4-byte header
+	// cannot exceed 65535 bytes. Guard the conversion below so an oversized
+	// ApplicationData payload errors instead of silently wrapping into a tiny,
+	// corrupt Header.Size.
+	totalSize := len(marshalledData) + headerSize
+	if totalSize > 0xFFFF {
+		return nil, fmt.Errorf("ACE too large to marshal: size %d exceeds the uint16 Header.Size maximum (65535)", totalSize)
+	}
+	if ace.Header.Size > uint16(totalSize) {
 		// Pad the marshalled data to the size specified in the ACE header
 		for uint32(len(marshalledData)+headerSize) < uint32(ace.Header.Size) {
 			marshalledData = append(marshalledData, 0)
 		}
 	} else {
-		ace.Header.Size = uint16(len(marshalledData) + headerSize)
+		ace.Header.Size = uint16(totalSize)
 	}
 
 	// Marshal Header and append at start of marshalled data

--- a/ace/AccessControlEntry_overflow_test.go
+++ b/ace/AccessControlEntry_overflow_test.go
@@ -1,0 +1,36 @@
+package ace_test
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/winacl/ace"
+	"github.com/TheManticoreProject/winacl/ace/acetype"
+)
+
+// TestACE_Marshal_OversizedApplicationData verifies that marshalling an ACE
+// whose body would exceed the uint16 Header.Size field returns an error instead
+// of silently wrapping into a tiny, corrupt size.
+func TestACE_Marshal_OversizedApplicationData(t *testing.T) {
+	a := ace.AccessControlEntry{}
+	a.Header.Type.Value = acetype.ACE_TYPE_ACCESS_ALLOWED_CALLBACK
+	a.Mask.SetRights([]uint32{0x00000001})
+	a.Identity.SID.FromString("S-1-1-0")
+	a.ApplicationData = make([]byte, 0x10000) // 65536 bytes: body + header > 65535
+
+	if _, err := a.Marshal(); err == nil {
+		t.Error("Marshal() = nil error, want error for ACE exceeding the uint16 Header.Size maximum")
+	}
+}
+
+// TestACE_Marshal_NormalSizeOK verifies the overflow guard does not affect a
+// normally sized ACE.
+func TestACE_Marshal_NormalSizeOK(t *testing.T) {
+	a := ace.AccessControlEntry{}
+	a.Header.Type.Value = acetype.ACE_TYPE_ACCESS_ALLOWED
+	a.Mask.SetRights([]uint32{0x00000001})
+	a.Identity.SID.FromString("S-1-1-0")
+
+	if _, err := a.Marshal(); err != nil {
+		t.Fatalf("Marshal() of a normal ACE error = %v", err)
+	}
+}

--- a/acl/AccessControlList_overflow_test.go
+++ b/acl/AccessControlList_overflow_test.go
@@ -1,0 +1,64 @@
+package acl_test
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/winacl/ace"
+	"github.com/TheManticoreProject/winacl/ace/acetype"
+	"github.com/TheManticoreProject/winacl/acl"
+	"github.com/TheManticoreProject/winacl/acl/revision"
+)
+
+// largeCallbackACE builds a callback ACE carrying appDataLen bytes of
+// ApplicationData. With appDataLen well under 65535 each ACE marshals fine; a
+// few of them combined push the ACL body past the uint16 AclSize limit.
+func largeCallbackACE(appDataLen int) ace.AccessControlEntry {
+	e := ace.AccessControlEntry{}
+	e.Header.Type.Value = acetype.ACE_TYPE_ACCESS_ALLOWED_CALLBACK
+	e.Mask.SetRights([]uint32{0x00000001})
+	e.Identity.SID.FromString("S-1-1-0")
+	e.ApplicationData = make([]byte, appDataLen)
+	return e
+}
+
+// TestDACL_Marshal_OversizedAclSize verifies that marshalling a DACL whose body
+// exceeds the uint16 AclSize field returns an error instead of wrapping.
+func TestDACL_Marshal_OversizedAclSize(t *testing.T) {
+	dacl := &acl.DiscretionaryAccessControlList{}
+	dacl.Header.Revision.SetRevision(revision.ACL_REVISION_DS)
+	for i := 0; i < 3; i++ {
+		dacl.AddEntry(largeCallbackACE(23000)) // ~23020 bytes each, < 65535
+	}
+
+	if _, err := dacl.Marshal(); err == nil {
+		t.Error("Marshal() = nil error, want error for DACL exceeding the uint16 AclSize maximum")
+	}
+}
+
+// TestSACL_Marshal_OversizedAclSize verifies the same guard for the SACL.
+func TestSACL_Marshal_OversizedAclSize(t *testing.T) {
+	sacl := &acl.SystemAccessControlList{}
+	sacl.Header.Revision.SetRevision(revision.ACL_REVISION_DS)
+	for i := 0; i < 3; i++ {
+		sacl.AddEntry(largeCallbackACE(23000))
+	}
+
+	if _, err := sacl.Marshal(); err == nil {
+		t.Error("Marshal() = nil error, want error for SACL exceeding the uint16 AclSize maximum")
+	}
+}
+
+// TestDACL_Marshal_NormalSizeOK verifies the guard does not affect a normal DACL.
+func TestDACL_Marshal_NormalSizeOK(t *testing.T) {
+	dacl := &acl.DiscretionaryAccessControlList{}
+	dacl.Header.Revision.SetRevision(revision.ACL_REVISION_DS)
+	entry := ace.AccessControlEntry{}
+	entry.Header.Type.Value = acetype.ACE_TYPE_ACCESS_ALLOWED
+	entry.Mask.SetRights([]uint32{0x00000001})
+	entry.Identity.SID.FromString("S-1-1-0")
+	dacl.AddEntry(entry)
+
+	if _, err := dacl.Marshal(); err != nil {
+		t.Fatalf("Marshal() of a normal DACL error = %v", err)
+	}
+}

--- a/acl/DiscretionaryAccessControlList.go
+++ b/acl/DiscretionaryAccessControlList.go
@@ -68,7 +68,11 @@ func (dacl *DiscretionaryAccessControlList) Marshal() ([]byte, error) {
 
 	// Marshal the header at the beginning of the serialized data
 	// We need to include the header in the size calculation, it is 8 bytes long
-	dacl.Header.AclSize = uint16(8 + len(marshalledData))
+	totalSize := 8 + len(marshalledData)
+	if totalSize > 0xFFFF {
+		return nil, fmt.Errorf("DACL too large to marshal: size %d exceeds the uint16 AclSize maximum (65535)", totalSize)
+	}
+	dacl.Header.AclSize = uint16(totalSize)
 	bytesStream, err := dacl.Header.Marshal()
 	if err != nil {
 		return nil, err

--- a/acl/SystemAccessControlList.go
+++ b/acl/SystemAccessControlList.go
@@ -70,7 +70,11 @@ func (sacl *SystemAccessControlList) Marshal() ([]byte, error) {
 
 	// Marshal the header at the beginning of the serialized data
 	// We need to include the header in the size calculation, it is 8 bytes long
-	sacl.Header.AclSize = uint16(8 + len(marshalledData))
+	totalSize := 8 + len(marshalledData)
+	if totalSize > 0xFFFF {
+		return nil, fmt.Errorf("SACL too large to marshal: size %d exceeds the uint16 AclSize maximum (65535)", totalSize)
+	}
+	sacl.Header.AclSize = uint16(totalSize)
 	bytesStream, err := sacl.Header.Marshal()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
### Linked Issue
`Closes #79`

### Motivation
`AclSize` (ACL header) and `Header.Size` (ACE header) are `uint16` fields. The marshallers computed them with unchecked conversions (`uint16(8 + len(...))` and `uint16(len(...) + headerSize)`). A DACL with many/large ACEs, or an ACE with a large `ApplicationData` payload (resource-attribute / conditional-expression ACEs), can legitimately exceed 64 KB, at which point the cast wraps modulo 65536 and writes a structurally invalid, too-small size. Returning an error is far safer than emitting silently corrupt output a reader would then truncate.

### What Changed
- `DiscretionaryAccessControlList.Marshal` and `SystemAccessControlList.Marshal` compute `totalSize = 8 + len(body)` and return an error if it exceeds `0xFFFF` before assigning `Header.AclSize`.
- `AccessControlEntry.Marshal` computes `totalSize = len(body) + headerSize` and returns an error if it exceeds `0xFFFF`; the existing size comparison and the `Header.Size` assignment now both use that validated value, so the guard covers the comparison branch as well as the assignment.

### Acceptance Criteria Check
- [x] Marshalling an ACL whose body exceeds 65535 bytes errors instead of wrapping — `TestDACL_Marshal_OversizedAclSize`, `TestSACL_Marshal_OversizedAclSize`.
- [x] Marshalling an ACE whose body + header exceeds 65535 bytes errors instead of wrapping — `TestACE_Marshal_OversizedApplicationData`.
- [x] Normal-sized ACLs/ACEs marshal as before — `TestDACL_Marshal_NormalSizeOK`, `TestACE_Marshal_NormalSizeOK`, plus the full existing suite including the real-dataset involution test.
- [x] New tests in `acl/` and `ace/` cover the overflow boundary.

### How Verified
- **Tests:** `ace/AccessControlEntry_overflow_test.go` and `acl/AccessControlList_overflow_test.go` (oversized cases error; normal cases succeed).
- `go build ./...` and `go test ./...` pass.

### Test Coverage
- **Added:** the overflow/normal tests listed above for both ACL types and the ACE.

### Scope of Change
- **Files changed:** `acl/DiscretionaryAccessControlList.go`, `acl/SystemAccessControlList.go`, `ace/AccessControlEntry.go`, `acl/AccessControlList_overflow_test.go`, `ace/AccessControlEntry_overflow_test.go`
- **Submodule pointer updated:** no
- **Public API changes:** none; `Marshal` may now return an error in the overflow case where it previously returned silently-wrong bytes
- **Behavioral changes outside the stated enhancement:** none

### Risk and Rollout
Low. Normal-sized data marshals byte-identically (verified by the dataset involution test); only inputs that genuinely cannot fit the 16-bit size fields now error instead of producing corrupt output. Safe to merge.