### PR TITLE
Make RightToSDDL reverse map deterministic for colliding mask values (#81)

### DIFF
--- a/sddl/rights/rights.go
+++ b/sddl/rights/rights.go
@@ -1,6 +1,8 @@
 package rights
 
 import (
+	"sort"
+
 	ntsd_rights "github.com/TheManticoreProject/winacl/rights"
 )
 
@@ -53,7 +55,23 @@ var RightToSDDL map[uint32]string
 
 func init() {
 	RightToSDDL = make(map[uint32]string, len(SDDLToRight))
-	for sddl, right := range SDDLToRight {
-		RightToSDDL[right] = sddl
+
+	// Several SDDL tokens can share the same access-mask value (e.g. "KR"
+	// KEY_READ and "KX" KEY_EXECUTE are both 0x00020019). Inverting the map by
+	// ranging over it directly would pick a winner at random per run, because Go
+	// randomises map iteration order. Iterate the tokens in sorted order and keep
+	// the first (lexicographically smallest) token for each mask, so the reverse
+	// lookup is deterministic and the canonical token is stable across runs.
+	tokens := make([]string, 0, len(SDDLToRight))
+	for sddl := range SDDLToRight {
+		tokens = append(tokens, sddl)
+	}
+	sort.Strings(tokens)
+
+	for _, sddl := range tokens {
+		right := SDDLToRight[sddl]
+		if _, exists := RightToSDDL[right]; !exists {
+			RightToSDDL[right] = sddl
+		}
 	}
 }

--- a/sddl/rights/rights_test.go
+++ b/sddl/rights/rights_test.go
@@ -1,0 +1,40 @@
+package rights_test
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/winacl/sddl/rights"
+)
+
+// TestRightToSDDL_CollisionDeterministic verifies that the reverse map resolves
+// the KR/KX mask collision (both 0x00020019) to a stable canonical token.
+func TestRightToSDDL_CollisionDeterministic(t *testing.T) {
+	const keyReadExecute = 0x00020019
+
+	got, ok := rights.RightToSDDL[keyReadExecute]
+	if !ok {
+		t.Fatalf("RightToSDDL[0x%08x] missing", keyReadExecute)
+	}
+	// "KR" sorts before "KX", so it is the deterministic winner.
+	if got != "KR" {
+		t.Errorf("RightToSDDL[0x%08x] = %q, want %q", keyReadExecute, got, "KR")
+	}
+}
+
+// TestRightToSDDL_IsValidInverse verifies that every mask present in the reverse
+// map resolves to a token that maps back to that same mask in SDDLToRight, i.e.
+// the reverse map is a valid inverse for every entry.
+func TestRightToSDDL_IsValidInverse(t *testing.T) {
+	for mask, token := range rights.RightToSDDL {
+		if rights.SDDLToRight[token] != mask {
+			t.Errorf("RightToSDDL[0x%08x] = %q, but SDDLToRight[%q] = 0x%08x", mask, token, token, rights.SDDLToRight[token])
+		}
+	}
+
+	// Every forward mask must be representable in the reverse map.
+	for token, mask := range rights.SDDLToRight {
+		if _, ok := rights.RightToSDDL[mask]; !ok {
+			t.Errorf("mask 0x%08x (from token %q) has no entry in RightToSDDL", mask, token)
+		}
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #81`

### Motivation
`RightToSDDL` was built in `init()` by ranging over `SDDLToRight` and assigning `RightToSDDL[right] = sddl`. Two distinct tokens map to the same mask — `"KR"` (KEY_READ) and `"KX"` (KEY_EXECUTE) are both `0x00020019` — so the surviving token for that value depended on Go's randomized map-iteration order and changed between runs. Any consumer rendering a mask back to an SDDL token got an unstable, sometimes-wrong abbreviation.

### What Changed
- `init()` now collects the `SDDLToRight` tokens, sorts them, and inserts into `RightToSDDL` keeping the first (lexicographically smallest) token for each mask. For the colliding value this deterministically yields `"KR"` (since `"KR" < "KX"`).
- Added `sort` import.

### Design Notes
Lexicographic first-wins is a deterministic, documented tie-break that requires no second source of truth to maintain. `"KR"` is the natural canonical token for `0x00020019` (KEY_READ is the conventional rendering of that mask). The forward `SDDLToRight` map is unchanged, so both `"KR"` and `"KX"` still parse to `0x00020019`.

### Acceptance Criteria Check
- [x] `RightToSDDL[0x00020019]` returns the same token on every run — `TestRightToSDDL_CollisionDeterministic` asserts it is `"KR"`; the sorted-iteration construction makes it run-independent.
- [x] A test asserts the chosen token for the colliding value and that all other entries round-trip — `TestRightToSDDL_CollisionDeterministic` and `TestRightToSDDL_IsValidInverse` (every reverse entry maps back to its mask, and every forward mask is representable).
- [x] No change to `SDDLToRight` parsing behavior — the forward map is untouched.

### How Verified
- **Tests:** `sddl/rights/rights_test.go` — `TestRightToSDDL_CollisionDeterministic`, `TestRightToSDDL_IsValidInverse`.
- `go build ./...` and `go test ./...` pass.

### Test Coverage
- **Added:** the two tests above (first tests in the `sddl/rights` package).

### Scope of Change
- **Files changed:** `sddl/rights/rights.go`, `sddl/rights/rights_test.go`
- **Submodule pointer updated:** no
- **Public API changes:** none; `RightToSDDL` lookups become deterministic
- **Behavioral changes outside the stated enhancement:** none

### Risk and Rollout
Trivial and local; only the previously-random winner for colliding masks is now fixed. Safe to merge.