### PR TITLE
Reject NtSecurityDescriptor component offsets inside the header (#90)

### DIFF
--- a/securitydescriptor/NtSecurityDescriptor.go
+++ b/securitydescriptor/NtSecurityDescriptor.go
@@ -9,6 +9,11 @@ import (
 	"github.com/TheManticoreProject/winacl/securitydescriptor/header"
 )
 
+// ntSecurityDescriptorHeaderSize is the fixed size, in bytes, of the security
+// descriptor header. A non-zero component offset must point at or past this
+// region; an offset inside the header overlaps it and is structurally invalid.
+const ntSecurityDescriptorHeaderSize uint32 = 20
+
 // NtSecurityDescriptor represents a Windows security descriptor.
 type NtSecurityDescriptor struct {
 	Header header.NtSecurityDescriptorHeader
@@ -43,11 +48,11 @@ func (ntsd *NtSecurityDescriptor) Unmarshal(marshalledData []byte) (int, error) 
 	// Track the maximum extent (offset + component size) across all components,
 	// since components are placed at specific offsets within the buffer rather
 	// than sequentially.
-	ntsd.RawBytesSize = 20 // header size
+	ntsd.RawBytesSize = ntSecurityDescriptorHeaderSize // header size
 
 	// Unmarshal Owner if present
 	if ntsd.Header.OffsetOwner != 0 {
-		if ntsd.Header.OffsetOwner < uint32(len(ntsd.RawBytes)) {
+		if ntsd.Header.OffsetOwner >= ntSecurityDescriptorHeaderSize && ntsd.Header.OffsetOwner < uint32(len(ntsd.RawBytes)) {
 			if ntsd.Owner == nil {
 				ntsd.Owner = &identity.Identity{}
 			}
@@ -59,13 +64,13 @@ func (ntsd *NtSecurityDescriptor) Unmarshal(marshalledData []byte) (int, error) 
 				ntsd.RawBytesSize = end
 			}
 		} else {
-			return 0, fmt.Errorf("failed to unmarshal Owner: offset is out of bounds OffsetOwner=%d, RawBytesSize=%d", ntsd.Header.OffsetOwner, ntsd.RawBytesSize)
+			return 0, fmt.Errorf("failed to unmarshal Owner: offset is invalid OffsetOwner=%d (must be >= %d and < %d)", ntsd.Header.OffsetOwner, ntSecurityDescriptorHeaderSize, len(ntsd.RawBytes))
 		}
 	}
 
 	// Unmarshal Group if present
 	if ntsd.Header.OffsetGroup != 0 {
-		if ntsd.Header.OffsetGroup < uint32(len(ntsd.RawBytes)) {
+		if ntsd.Header.OffsetGroup >= ntSecurityDescriptorHeaderSize && ntsd.Header.OffsetGroup < uint32(len(ntsd.RawBytes)) {
 			if ntsd.Group == nil {
 				ntsd.Group = &identity.Identity{}
 			}
@@ -77,13 +82,13 @@ func (ntsd *NtSecurityDescriptor) Unmarshal(marshalledData []byte) (int, error) 
 				ntsd.RawBytesSize = end
 			}
 		} else {
-			return 0, fmt.Errorf("failed to unmarshal Group: offset is out of bounds OffsetGroup=%d, RawBytesSize=%d", ntsd.Header.OffsetGroup, ntsd.RawBytesSize)
+			return 0, fmt.Errorf("failed to unmarshal Group: offset is invalid OffsetGroup=%d (must be >= %d and < %d)", ntsd.Header.OffsetGroup, ntSecurityDescriptorHeaderSize, len(ntsd.RawBytes))
 		}
 	}
 
 	// Unmarshal DACL if present
 	if ntsd.Header.OffsetDacl != 0 {
-		if ntsd.Header.OffsetDacl < uint32(len(ntsd.RawBytes)) {
+		if ntsd.Header.OffsetDacl >= ntSecurityDescriptorHeaderSize && ntsd.Header.OffsetDacl < uint32(len(ntsd.RawBytes)) {
 			if ntsd.DACL == nil {
 				ntsd.DACL = &acl.DiscretionaryAccessControlList{}
 			}
@@ -95,13 +100,13 @@ func (ntsd *NtSecurityDescriptor) Unmarshal(marshalledData []byte) (int, error) 
 				ntsd.RawBytesSize = end
 			}
 		} else {
-			return 0, fmt.Errorf("failed to unmarshal DACL: offset is out of bounds OffsetDacl=%d, RawBytesSize=%d", ntsd.Header.OffsetDacl, ntsd.RawBytesSize)
+			return 0, fmt.Errorf("failed to unmarshal DACL: offset is invalid OffsetDacl=%d (must be >= %d and < %d)", ntsd.Header.OffsetDacl, ntSecurityDescriptorHeaderSize, len(ntsd.RawBytes))
 		}
 	}
 
 	// Unmarshal SACL if present
 	if ntsd.Header.OffsetSacl != 0 {
-		if ntsd.Header.OffsetSacl < uint32(len(ntsd.RawBytes)) {
+		if ntsd.Header.OffsetSacl >= ntSecurityDescriptorHeaderSize && ntsd.Header.OffsetSacl < uint32(len(ntsd.RawBytes)) {
 			if ntsd.SACL == nil {
 				ntsd.SACL = &acl.SystemAccessControlList{}
 			}
@@ -113,7 +118,7 @@ func (ntsd *NtSecurityDescriptor) Unmarshal(marshalledData []byte) (int, error) 
 				ntsd.RawBytesSize = end
 			}
 		} else {
-			return 0, fmt.Errorf("failed to unmarshal SACL: offset is out of bounds OffsetSacl=%d, RawBytesSize=%d", ntsd.Header.OffsetSacl, ntsd.RawBytesSize)
+			return 0, fmt.Errorf("failed to unmarshal SACL: offset is invalid OffsetSacl=%d (must be >= %d and < %d)", ntsd.Header.OffsetSacl, ntSecurityDescriptorHeaderSize, len(ntsd.RawBytes))
 		}
 	}
 

--- a/securitydescriptor/NtSecurityDescriptor_offset_test.go
+++ b/securitydescriptor/NtSecurityDescriptor_offset_test.go
@@ -1,0 +1,35 @@
+package securitydescriptor_test
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/TheManticoreProject/winacl/securitydescriptor"
+)
+
+// TestNtSecurityDescriptor_Unmarshal_OffsetInsideHeader verifies that a
+// component offset pointing inside the 20-byte header is rejected instead of
+// being parsed as garbage.
+func TestNtSecurityDescriptor_Unmarshal_OffsetInsideHeader(t *testing.T) {
+	ntsd := securitydescriptor.NewSecurityDescriptor()
+	ntsd.Owner.SID.FromString("S-1-5-32-544")
+
+	data, err := ntsd.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+
+	// Sanity check: the unmodified descriptor parses cleanly.
+	if _, err := (&securitydescriptor.NtSecurityDescriptor{}).Unmarshal(data); err != nil {
+		t.Fatalf("Unmarshal() of valid descriptor error = %v", err)
+	}
+
+	// OffsetOwner is the little-endian uint32 at bytes 4..8. Point it inside the
+	// header region (offset 4) to simulate a malformed/crafted descriptor.
+	binary.LittleEndian.PutUint32(data[4:8], 4)
+
+	parsed := &securitydescriptor.NtSecurityDescriptor{}
+	if _, err := parsed.Unmarshal(data); err == nil {
+		t.Error("Unmarshal() = nil error, want error for an owner offset inside the header")
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #90`

### Motivation
`NtSecurityDescriptor.Unmarshal` validated each component offset only with `Offset < len(RawBytes)`. With no lower bound, a non-zero offset pointing into the fixed 20-byte header (for example `OffsetOwner = 4`) was accepted and the header bytes were mis-parsed as a SID/ACL, producing garbage rather than an error. For a parser of untrusted security descriptors, an offset overlapping the header is structurally invalid and should be rejected. This complements the `AclSize` bound for ACLs (#78): together they confine each component to a valid region.

### What Changed
- Added the package constant `ntSecurityDescriptorHeaderSize = 20` and used it for the existing `RawBytesSize` initialization as well as the new checks.
- Each component guard in `Unmarshal` (Owner, Group, DACL, SACL) now requires `Offset >= ntSecurityDescriptorHeaderSize && Offset < len(RawBytes)`; the error messages were updated to state the valid range.

### Acceptance Criteria Check
- [x] A descriptor whose component offset is non-zero but less than 20 returns an error — `TestNtSecurityDescriptor_Unmarshal_OffsetInsideHeader` (sets `OffsetOwner = 4`).
- [x] `Offset == 0` (component absent) is still skipped without error — unchanged outer `!= 0` guard; covered by the dataset involution tests, which include descriptors with absent components.
- [x] Well-formed descriptors parse unchanged — `go test ./...` green, including `TestNtSecurityDescriptor_Involution` over the real Windows/AD datasets; the new test also asserts the unmodified descriptor parses cleanly before corruption.
- [x] New test constructs a descriptor with an in-header offset and asserts an error — see above.

### How Verified
- **Tests:** `securitydescriptor/NtSecurityDescriptor_offset_test.go` — `TestNtSecurityDescriptor_Unmarshal_OffsetInsideHeader`.
- `go build ./...` and `go test ./...` pass.

### Test Coverage
- **Added:** the test above.

### Scope of Change
- **Files changed:** `securitydescriptor/NtSecurityDescriptor.go`, `securitydescriptor/NtSecurityDescriptor_offset_test.go`
- **Submodule pointer updated:** no
- **Public API changes:** none (behavioral hardening of `Unmarshal`; it may now return an error on malformed offsets it previously mis-parsed)
- **Behavioral changes outside the stated enhancement:** none

### Risk and Rollout
Low. Well-formed descriptors place every component at or past the 20-byte header, so valid input is unaffected (verified by the dataset involution test); only offsets that overlap the header now error. Safe to merge.

### Notes
Related: #78 (bound ACL parsing by AclSize), #82 (Marshal no longer emits offsets for an unset Owner/Group). Full mutual-extent overlap checking between components is deferred as noted in the issue.