### PR TITLE
Fix AccessControlEntryFlag.Unmarshal appending NONE to every ACE (Fixes #94)

### DIFF
--- a/ace/aceflags/AccessControlEntryFlags.go
+++ b/ace/aceflags/AccessControlEntryFlags.go
@@ -87,10 +87,21 @@ func (aceflag *AccessControlEntryFlag) Unmarshal(marshalledData []byte) (int, er
 	aceflag.Flags = []string{}
 
 	for flagValue, flagName := range AccessControlEntryFlagToName {
+		// Skip the zero-valued NONE flag: its bitmask test is always true and
+		// would otherwise be reported for every ACE. It is handled explicitly
+		// below when no flag bits are set.
+		if flagValue == ACE_FLAG_NONE {
+			continue
+		}
 		if (aceflag.RawValue & flagValue) == flagValue {
 			aceflag.Values = append(aceflag.Values, flagValue)
 			aceflag.Flags = append(aceflag.Flags, flagName)
 		}
+	}
+
+	if aceflag.RawValue == ACE_FLAG_NONE {
+		aceflag.Values = append(aceflag.Values, ACE_FLAG_NONE)
+		aceflag.Flags = append(aceflag.Flags, AccessControlEntryFlagToName[ACE_FLAG_NONE])
 	}
 
 	return 1, nil

--- a/ace/aceflags/AccessControlEntryFlags_test.go
+++ b/ace/aceflags/AccessControlEntryFlags_test.go
@@ -16,3 +16,41 @@ func TestAccessControlEntryFlag_Unmarshal_EmptyReturnsError(t *testing.T) {
 		t.Fatal("expected an error for empty input, got nil")
 	}
 }
+
+// TestAccessControlEntryFlag_Unmarshal_NoneNotSetWhenFlagsPresent is a
+// regression test for issue #94: the zero-valued NONE flag must not be
+// reported when actual flag bits are set.
+func TestAccessControlEntryFlag_Unmarshal_NoneNotSetWhenFlagsPresent(t *testing.T) {
+	f := aceflags.AccessControlEntryFlag{}
+	if _, err := f.Unmarshal([]byte{aceflags.ACE_FLAG_OBJECT_INHERIT}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := f.String(); got != "OBJECT_INHERIT" {
+		t.Fatalf("expected flags %q, got %q", "OBJECT_INHERIT", got)
+	}
+
+	for _, name := range f.Flags {
+		if name == "NONE" {
+			t.Fatalf("NONE must not be present when flag bits are set, got flags %v", f.Flags)
+		}
+	}
+	for _, v := range f.Values {
+		if v == aceflags.ACE_FLAG_NONE {
+			t.Fatalf("ACE_FLAG_NONE must not be present when flag bits are set, got values %v", f.Values)
+		}
+	}
+}
+
+// TestAccessControlEntryFlag_Unmarshal_NoneWhenNoBitsSet verifies that NONE is
+// reported when no flag bits are set.
+func TestAccessControlEntryFlag_Unmarshal_NoneWhenNoBitsSet(t *testing.T) {
+	f := aceflags.AccessControlEntryFlag{}
+	if _, err := f.Unmarshal([]byte{aceflags.ACE_FLAG_NONE}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got := f.String(); got != "NONE" {
+		t.Fatalf("expected flags %q, got %q", "NONE", got)
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #94`

### Root Cause
`ACE_FLAG_NONE` is defined with value `0x00`. The unmarshalling loop tests each known flag with the bitmask membership expression `(aceflag.RawValue & flagValue) == flagValue`. For a zero-valued mask this reduces to `(RawValue & 0) == 0`, i.e. `0 == 0`, which is unconditionally true. As a result the zero-valued `NONE` flag matched every input and was appended to the flag list of every ACE.

### Fix Description
The zero-valued `ACE_FLAG_NONE` entry is now skipped inside the bitmask loop, since it cannot be meaningfully detected by a bitwise AND. `NONE` is instead reported explicitly, and only, when no flag bits are set (`RawValue == 0x00`). This preserves the semantic that a flag byte of `0x00` reports `NONE` while any non-zero byte reports only the flags actually set.

### How Verified
- **Runtime (before):** unmarshalling `0x01` produced `NONE|OBJECT_INHERIT`.
- **Runtime (after):** unmarshalling `0x01` produces `OBJECT_INHERIT`; unmarshalling `0x00` produces `NONE`.
- **Tests:** `go test ./...` passes across the module.

### Test Coverage
- **Added:**
  - `TestAccessControlEntryFlag_Unmarshal_NoneNotSetWhenFlagsPresent` — asserts `NONE` is absent from both `Flags` and `Values` when a flag bit is set (`0x01` → `OBJECT_INHERIT`).
  - `TestAccessControlEntryFlag_Unmarshal_NoneWhenNoBitsSet` — asserts `0x00` still reports `NONE`.
  - File: `ace/aceflags/AccessControlEntryFlags_test.go`

### Scope of Change
- **Files changed:** `ace/aceflags/AccessControlEntryFlags.go`, `ace/aceflags/AccessControlEntryFlags_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local to `AccessControlEntryFlag.Unmarshal`. Consumers that previously matched on the presence of `NONE` in a non-empty flag set (an incorrect state) would see it removed; the `RawValue == 0x00 → NONE` behavior is unchanged. Safe to merge.