### PR TITLE
[bug] Fix Marshal dropping present-but-empty DACL/SACL (Fixes #96)

### DIFF
--- a/securitydescriptor/NtSecurityDescriptor.go
+++ b/securitydescriptor/NtSecurityDescriptor.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/TheManticoreProject/winacl/acl"
 	"github.com/TheManticoreProject/winacl/identity"
+	"github.com/TheManticoreProject/winacl/securitydescriptor/control"
 	"github.com/TheManticoreProject/winacl/securitydescriptor/header"
 )
 
@@ -136,9 +137,14 @@ func (ntsd *NtSecurityDescriptor) Marshal() ([]byte, error) {
 
 	offset := 20
 
-	// Marshal SACL
+	// Marshal SACL. A SACL that is present must be emitted even when it holds
+	// zero ACEs: per MS-DTYP 2.4.6, presence is governed by the SE_SACL_PRESENT
+	// control bit, and an empty-but-present SACL is semantically distinct from
+	// an absent (NULL) SACL. Gating solely on the ACE count would drop a
+	// present-but-empty SACL while leaving SE_SACL_PRESENT set, producing an
+	// inconsistent descriptor that no longer round-trips.
 	dataSacl := []byte{}
-	if ntsd.SACL != nil && len(ntsd.SACL.Entries) > 0 {
+	if ntsd.SACL != nil && (len(ntsd.SACL.Entries) > 0 || ntsd.Header.Control.HasControl(control.NT_SECURITY_DESCRIPTOR_CONTROL_SP)) {
 		dataSacl, err = ntsd.SACL.Marshal()
 		if err != nil {
 			return nil, fmt.Errorf("failed to marshal SACL: %w", err)
@@ -149,9 +155,12 @@ func (ntsd *NtSecurityDescriptor) Marshal() ([]byte, error) {
 		ntsd.Header.OffsetSacl = 0
 	}
 
-	// Marshal DACL
+	// Marshal DACL. See the SACL note above: a present-but-empty DACL
+	// (SE_DACL_PRESENT set, zero ACEs) must be preserved. Dropping it would
+	// silently convert an empty DACL (which denies all access) into an absent
+	// NULL DACL (which grants everyone full access).
 	dataDacl := []byte{}
-	if ntsd.DACL != nil && len(ntsd.DACL.Entries) > 0 {
+	if ntsd.DACL != nil && (len(ntsd.DACL.Entries) > 0 || ntsd.Header.Control.HasControl(control.NT_SECURITY_DESCRIPTOR_CONTROL_DP)) {
 		dataDacl, err = ntsd.DACL.Marshal()
 		if err != nil {
 			return nil, fmt.Errorf("failed to marshal DACL: %w", err)

--- a/securitydescriptor/NtSecurityDescriptor_empty_acl_test.go
+++ b/securitydescriptor/NtSecurityDescriptor_empty_acl_test.go
@@ -1,0 +1,75 @@
+package securitydescriptor_test
+
+import (
+	"encoding/hex"
+	"testing"
+
+	"github.com/TheManticoreProject/winacl/securitydescriptor"
+	"github.com/TheManticoreProject/winacl/securitydescriptor/control"
+)
+
+// TestNtSecurityDescriptor_Marshal_PresentEmptyDACL is a regression test for
+// the bug where Marshal dropped a present-but-empty DACL (SE_DACL_PRESENT set,
+// zero ACEs), setting OffsetDacl = 0 while leaving SE_DACL_PRESENT in Control.
+// That corrupted the descriptor and converted an empty DACL (deny-all) into an
+// absent NULL DACL (allow-all) on the next parse.
+//
+// Wire layout (28 bytes):
+//
+//	Revision   = 0x01
+//	Sbz1       = 0x00
+//	Control    = 0x8004 (SE_SELF_RELATIVE | SE_DACL_PRESENT), little-endian 0x04 0x80
+//	OffsetOwner= 0
+//	OffsetGroup= 0
+//	OffsetSacl = 0
+//	OffsetDacl = 20
+//	DACL       = AclRevision 0x02, Sbz1 0x00, AclSize 8, AceCount 0, Sbz2 0
+func TestNtSecurityDescriptor_Marshal_PresentEmptyDACL(t *testing.T) {
+	const input = "0100048000000000000000000000000014000000" + "0200080000000000"
+
+	inputBytes, err := hex.DecodeString(input)
+	if err != nil {
+		t.Fatalf("failed to decode input: %v", err)
+	}
+
+	ntsd := &securitydescriptor.NtSecurityDescriptor{}
+	if _, err := ntsd.Unmarshal(inputBytes); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+
+	if ntsd.DACL == nil {
+		t.Fatal("parsed DACL is nil; a present DACL (SE_DACL_PRESENT set) must be non-nil")
+	}
+	if !ntsd.Header.Control.HasControl(control.NT_SECURITY_DESCRIPTOR_CONTROL_DP) {
+		t.Fatal("SE_DACL_PRESENT must remain set after Unmarshal")
+	}
+
+	out, err := ntsd.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+
+	// The present-but-empty DACL must survive Marshal: the output must be
+	// byte-identical to the input (offset preserved, DACL bytes re-emitted).
+	if got := hex.EncodeToString(out); got != input {
+		t.Fatalf("Marshal() = %s, want %s (present-but-empty DACL was dropped)", got, input)
+	}
+
+	// The control bit and the DACL offset must stay consistent.
+	if ntsd.Header.OffsetDacl == 0 {
+		t.Fatal("OffsetDacl = 0 after Marshal; a present DACL must keep a non-zero offset")
+	}
+
+	// Re-parsing the marshalled bytes must still yield a present (non-nil) DACL,
+	// i.e. the empty-vs-NULL DACL semantics are preserved across the round-trip.
+	reparsed := &securitydescriptor.NtSecurityDescriptor{}
+	if _, err := reparsed.Unmarshal(out); err != nil {
+		t.Fatalf("re-Unmarshal() error = %v", err)
+	}
+	if reparsed.DACL == nil {
+		t.Fatal("re-parsed DACL is nil; empty DACL was silently converted to a NULL (allow-all) DACL")
+	}
+	if !reparsed.Header.Control.HasControl(control.NT_SECURITY_DESCRIPTOR_CONTROL_DP) {
+		t.Fatal("SE_DACL_PRESENT lost across round-trip")
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #96`

### Root Cause
`NtSecurityDescriptor.Marshal` decided whether to emit a DACL/SACL from the ACE count (`len(Entries) > 0`) rather than from the `SE_DACL_PRESENT` / `SE_SACL_PRESENT` control bit that MS-DTYP 2.4.6 uses to govern ACL presence. A DACL that is *present but empty* (control bit set, zero ACEs) is a valid, parseable state; treating "empty" as "absent" on write dropped the ACL bytes and forced its offset to 0 while the present bit stayed set. On re-parse the DACL became NULL — and per MS-DTYP an empty DACL denies all access whereas a NULL DACL grants everyone full access, so re-serialization silently weakened access control and broke the round-trip.

### Fix Description
The SACL/DACL emission gate now also honors the presence control bit:
`ntsd.SACL != nil && (len(Entries) > 0 || Control.HasControl(SE_SACL_PRESENT))` (and the DACL equivalent). A present ACL is therefore re-emitted with a non-zero offset even with zero ACEs, so empty-vs-NULL semantics survive Marshal. The ACE-count branch is retained so no existing behavior changes for non-empty ACLs. This is the minimal change that keeps presence driven by the control bit without altering the offset/append machinery.

### How Verified
- **Runtime:** a 28-byte self-relative descriptor with a present-but-empty DACL (`Control = 0x8004`, `OffsetDacl = 20`, `AceCount = 0`) now marshals byte-identically and re-parses with a non-nil DACL and `SE_DACL_PRESENT` still set. Before the fix it marshalled to 20 bytes and re-parsed with `DACL == nil`.
- **Tests:** `go test ./...` passes, including the existing byte-exact involution suite over captured Active Directory descriptors (unchanged, since real self-relative descriptors carry both the present bit and non-empty ACLs).

### Test Coverage
- **Added:** `TestNtSecurityDescriptor_Marshal_PresentEmptyDACL` in `securitydescriptor/NtSecurityDescriptor_empty_acl_test.go` — asserts a present-but-empty DACL survives Marshal byte-for-byte and round-trips with the present bit intact.

### Scope of Change
- **Files changed:** `securitydescriptor/NtSecurityDescriptor.go`, `securitydescriptor/NtSecurityDescriptor_empty_acl_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Local to `Marshal`. Only descriptors with a present-but-empty ACL change output (previously corrupted, now correct); non-empty and absent ACLs are unaffected. Safe to merge.