### PR TITLE
[bug] Set SE_SELF_RELATIVE and DACL/SACL presence bits on constructed descriptors (Fixes #98)

### DIFF
--- a/securitydescriptor/NtSecurityDescriptor.go
+++ b/securitydescriptor/NtSecurityDescriptor.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/TheManticoreProject/winacl/acl"
 	"github.com/TheManticoreProject/winacl/identity"
+	"github.com/TheManticoreProject/winacl/securitydescriptor/control"
 	"github.com/TheManticoreProject/winacl/securitydescriptor/header"
 )
 
@@ -190,6 +191,15 @@ func (ntsd *NtSecurityDescriptor) Marshal() ([]byte, error) {
 	} else {
 		ntsd.Header.OffsetGroup = 0
 	}
+
+	// Marshal always serializes the descriptor in self-relative format (every
+	// component location is expressed as an offset into this contiguous buffer),
+	// so the SE_SELF_RELATIVE control bit must be set. Per MS-DTYP 2.4.6 a
+	// self-relative descriptor is required to carry this bit; without it a
+	// spec-compliant consumer would interpret the offset fields as absolute
+	// pointers. AddControl is idempotent, so descriptors parsed from the wire
+	// (which already have the bit set) are unaffected.
+	ntsd.Header.Control.AddControl(control.NT_SECURITY_DESCRIPTOR_CONTROL_SR)
 
 	// Update the header and append the header bytes
 	marshalledData, err = ntsd.Header.Marshal()

--- a/securitydescriptor/NtSecurityDescriptor_functions.go
+++ b/securitydescriptor/NtSecurityDescriptor_functions.go
@@ -7,6 +7,7 @@ import (
 	"github.com/TheManticoreProject/winacl/acl"
 	"github.com/TheManticoreProject/winacl/acl/revision"
 	"github.com/TheManticoreProject/winacl/identity"
+	"github.com/TheManticoreProject/winacl/securitydescriptor/control"
 	"github.com/TheManticoreProject/winacl/sid"
 )
 
@@ -278,6 +279,13 @@ func (ntsd *NtSecurityDescriptor) GetDacl() *acl.DiscretionaryAccessControlList 
 //   - dacl (acl.DiscretionaryAccessControlList): The new DACL field of the NtSecurityDescriptor.
 func (ntsd *NtSecurityDescriptor) SetDacl(dacl *acl.DiscretionaryAccessControlList) {
 	ntsd.DACL = dacl
+	// Attaching a DACL makes the descriptor's DACL present. Per MS-DTYP 2.4.6
+	// presence is signalled by the SE_DACL_PRESENT control bit, which Marshal
+	// relies on; without it a constructed descriptor would serialize a DACL
+	// offset while advertising "no DACL present" (a NULL, allow-all DACL).
+	if dacl != nil {
+		ntsd.Header.Control.AddControl(control.NT_SECURITY_DESCRIPTOR_CONTROL_DP)
+	}
 }
 
 // GetSacl returns the SACL field of the NtSecurityDescriptor.
@@ -294,6 +302,11 @@ func (ntsd *NtSecurityDescriptor) GetSacl() *acl.SystemAccessControlList {
 //   - sacl (acl.SystemAccessControlList): The new SACL field of the NtSecurityDescriptor.
 func (ntsd *NtSecurityDescriptor) SetSacl(sacl *acl.SystemAccessControlList) {
 	ntsd.SACL = sacl
+	// Attaching a SACL makes it present; signal that with SE_SACL_PRESENT so
+	// Marshal emits the SACL offset consistently (see SetDacl above).
+	if sacl != nil {
+		ntsd.Header.Control.AddControl(control.NT_SECURITY_DESCRIPTOR_CONTROL_SP)
+	}
 }
 
 // Equal compares two NtSecurityDescriptor instances for equality.

--- a/securitydescriptor/NtSecurityDescriptor_selfrelative_test.go
+++ b/securitydescriptor/NtSecurityDescriptor_selfrelative_test.go
@@ -1,0 +1,58 @@
+package securitydescriptor_test
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/TheManticoreProject/winacl/ace"
+	"github.com/TheManticoreProject/winacl/ace/acetype"
+	"github.com/TheManticoreProject/winacl/acl"
+	"github.com/TheManticoreProject/winacl/securitydescriptor"
+	"github.com/TheManticoreProject/winacl/securitydescriptor/control"
+)
+
+// TestNtSecurityDescriptor_Marshal_SetsSelfRelative verifies that a descriptor
+// built programmatically and marshalled carries SE_SELF_RELATIVE, since Marshal
+// always emits self-relative (offset-based) layout. Previously Marshal left the
+// control word untouched, so a NewSecurityDescriptor()+SetDacl()+Marshal()
+// produced self-relative bytes advertised as absolute-format (SR clear).
+func TestNtSecurityDescriptor_Marshal_SetsSelfRelative(t *testing.T) {
+	ntsd := securitydescriptor.NewSecurityDescriptor()
+
+	dacl := &acl.DiscretionaryAccessControlList{}
+	a := ace.AccessControlEntry{}
+	a.Header.Type.Value = acetype.ACE_TYPE_ACCESS_ALLOWED
+	a.Identity.SID.FromString("S-1-1-0")
+	dacl.AddEntry(a)
+	ntsd.SetDacl(dacl)
+
+	data, err := ntsd.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+
+	// SetDacl must set SE_DACL_PRESENT; Marshal must set SE_SELF_RELATIVE.
+	if !ntsd.Header.Control.HasControl(control.NT_SECURITY_DESCRIPTOR_CONTROL_SR) {
+		t.Error("SE_SELF_RELATIVE (0x8000) not set after Marshal")
+	}
+	if !ntsd.Header.Control.HasControl(control.NT_SECURITY_DESCRIPTOR_CONTROL_DP) {
+		t.Error("SE_DACL_PRESENT (0x0004) not set after SetDacl")
+	}
+
+	// The serialized control word must carry both bits.
+	ctrl := binary.LittleEndian.Uint16(data[2:4])
+	const wantMask = control.NT_SECURITY_DESCRIPTOR_CONTROL_SR | control.NT_SECURITY_DESCRIPTOR_CONTROL_DP
+	if ctrl&wantMask != wantMask {
+		t.Errorf("serialized control = 0x%04x, want SE_SELF_RELATIVE|SE_DACL_PRESENT (0x%04x) set", ctrl, wantMask)
+	}
+}
+
+// TestNtSecurityDescriptor_SetSacl_SetsPresent verifies SetSacl sets SE_SACL_PRESENT.
+func TestNtSecurityDescriptor_SetSacl_SetsPresent(t *testing.T) {
+	ntsd := securitydescriptor.NewSecurityDescriptor()
+	ntsd.SetSacl(&acl.SystemAccessControlList{})
+
+	if !ntsd.Header.Control.HasControl(control.NT_SECURITY_DESCRIPTOR_CONTROL_SP) {
+		t.Error("SE_SACL_PRESENT (0x0010) not set after SetSacl")
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #98`

### Root Cause
`Marshal` always serializes the descriptor in self-relative (offset-based) format but copied `Header.Control` to the wire verbatim, and the `SetDacl`/`SetSacl` setters were bare field assignments. The self-relative and ACL-presence control bits were therefore only ever established on the SDDL path (`FromSDDLString`). A descriptor built through the binary-construction API (`NewSecurityDescriptor()` + `SetDacl(...)`) carried `Control = 0x0000`, so its offset fields and DACL were spec-invalid: a compliant reader interprets offsets as absolute pointers (SR clear) and the DACL as absent (DACL-present clear).

### Fix Description
- `Marshal` now sets `SE_SELF_RELATIVE` via `Control.AddControl(...)` before serializing the header, because it unconditionally writes self-relative layout. `AddControl` is idempotent, so descriptors parsed from the wire (already SR-set) are byte-for-byte unchanged.
- `SetDacl` sets `SE_DACL_PRESENT` when a non-nil DACL is attached; `SetSacl` sets `SE_SACL_PRESENT`. Presence is thus signalled by the control bit that MS-DTYP 2.4.6 defines for it.

### How Verified
- **Runtime:** `NewSecurityDescriptor()` + `SetDacl(daclWithOneAce)` + `Marshal()` now yields a control word with `SE_SELF_RELATIVE|SE_DACL_PRESENT` (0x8004) set; `SetSacl` sets `SE_SACL_PRESENT`. Before the fix the control word was 0x0000.
- **Tests:** `go test ./...` passes, including the byte-exact involution suite over captured Active Directory descriptors — unaffected because those already carry `SE_SELF_RELATIVE`, so the idempotent `AddControl` is a no-op for them.

### Test Coverage
- **Added:** `TestNtSecurityDescriptor_Marshal_SetsSelfRelative` and `TestNtSecurityDescriptor_SetSacl_SetsPresent` in `securitydescriptor/NtSecurityDescriptor_selfrelative_test.go`.

### Scope of Change
- **Files changed:** `securitydescriptor/NtSecurityDescriptor.go`, `securitydescriptor/NtSecurityDescriptor_functions.go`, `securitydescriptor/NtSecurityDescriptor_selfrelative_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
`AddControl` is idempotent and round-trip descriptors already have `SE_SELF_RELATIVE`, so re-serialization of parsed descriptors is unchanged. Only programmatically constructed descriptors gain the (correct) control bits. Safe to merge.