### PR TITLE
[bug] Make AccessControlEntryFlag.Unmarshal produce deterministic flag ordering (Fixes #100)

### DIFF
--- a/ace/aceflags/AccessControlEntryFlags.go
+++ b/ace/aceflags/AccessControlEntryFlags.go
@@ -2,6 +2,7 @@ package aceflags
 
 import (
 	"fmt"
+	"sort"
 	"strings"
 )
 
@@ -86,16 +87,29 @@ func (aceflag *AccessControlEntryFlag) Unmarshal(marshalledData []byte) (int, er
 	aceflag.Values = []uint8{}
 	aceflag.Flags = []string{}
 
-	for flagValue, flagName := range AccessControlEntryFlagToName {
+	// Iterate the known flags in a deterministic (ascending value) order. Go
+	// randomizes map iteration order, so ranging AccessControlEntryFlagToName
+	// directly would fill Values/Flags in a nondeterministic order. Because
+	// Equal compares Values positionally, that made two flags parsed from the
+	// same byte compare unequal roughly half the time whenever more than one
+	// bit is set. Sorting the keys first (matching the idiom in
+	// ace/mask/AccessControlMask.go) makes the output stable.
+	flagValues := make([]uint8, 0, len(AccessControlEntryFlagToName))
+	for flagValue := range AccessControlEntryFlagToName {
 		// Skip the zero-valued NONE flag: its bitmask test is always true and
 		// would otherwise be reported for every ACE. It is handled explicitly
 		// below when no flag bits are set.
 		if flagValue == ACE_FLAG_NONE {
 			continue
 		}
+		flagValues = append(flagValues, flagValue)
+	}
+	sort.Slice(flagValues, func(i, j int) bool { return flagValues[i] < flagValues[j] })
+
+	for _, flagValue := range flagValues {
 		if (aceflag.RawValue & flagValue) == flagValue {
 			aceflag.Values = append(aceflag.Values, flagValue)
-			aceflag.Flags = append(aceflag.Flags, flagName)
+			aceflag.Flags = append(aceflag.Flags, AccessControlEntryFlagToName[flagValue])
 		}
 	}
 

--- a/ace/aceflags/AccessControlEntryFlags_order_test.go
+++ b/ace/aceflags/AccessControlEntryFlags_order_test.go
@@ -1,0 +1,42 @@
+package aceflags_test
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/winacl/ace/aceflags"
+)
+
+// TestAccessControlEntryFlag_Unmarshal_DeterministicEqual is a regression test
+// for the bug where Unmarshal filled the Values/Flags slices in randomized map
+// iteration order. Because Equal compares Values positionally, two flags parsed
+// from the same byte compared unequal roughly half the time whenever two or
+// more bits were set. After the fix the ordering is deterministic, so identical
+// bytes always compare Equal and produce an identical string.
+func TestAccessControlEntryFlag_Unmarshal_DeterministicEqual(t *testing.T) {
+	// 0x03 = OBJECT_INHERIT (0x01) | CONTAINER_INHERIT (0x02): two bits set.
+	const raw = 0x03
+
+	var first aceflags.AccessControlEntryFlag
+	if _, err := first.Unmarshal([]byte{raw}); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for i := 0; i < 1000; i++ {
+		var other aceflags.AccessControlEntryFlag
+		if _, err := other.Unmarshal([]byte{raw}); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !first.Equal(&other) {
+			t.Fatalf("iteration %d: two flags parsed from byte 0x%02x compare unequal (Values %v vs %v)",
+				i, raw, first.Values, other.Values)
+		}
+		if first.String() != other.String() {
+			t.Fatalf("iteration %d: nondeterministic String(): %q vs %q", i, first.String(), other.String())
+		}
+	}
+
+	// Deterministic order is ascending by flag value: OBJECT_INHERIT then CONTAINER_INHERIT.
+	if got := first.String(); got != "OBJECT_INHERIT|CONTAINER_INHERIT" {
+		t.Fatalf("String() = %q, want %q", got, "OBJECT_INHERIT|CONTAINER_INHERIT")
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #100`

### Root Cause
`Unmarshal` populated the `Values`/`Flags` slices by ranging `AccessControlEntryFlagToName`. Go randomizes map iteration order, so the slice order varied between calls on identical input. `Equal` compares `Values` element-by-element positionally (after an initial `RawValue` check that always matches for identical bytes), so an order difference made two flags parsed from the same byte compare unequal — nondeterministically, for any value with two or more bits set.

### Fix Description
`Unmarshal` now collects the known flag values (excluding the zero-valued `ACE_FLAG_NONE`), sorts them ascending, and iterates in that stable order — the same idiom already used in `ace/mask/AccessControlMask.go`. `Values`/`Flags` are therefore deterministic, so positional `Equal` and `String()` are stable. The `NONE`-handling behavior from the prior fix is preserved.

### How Verified
- **Runtime:** parsing byte `0x03` 1000 times and comparing each against a reference now yields `Equal == true` every time and a stable `String()` of `OBJECT_INHERIT|CONTAINER_INHERIT`. Before the fix, ~half of comparisons returned false.
- **Tests:** `go test ./...` passes, including the existing `aceflags` `Equal`/`Unmarshal` tests.

### Test Coverage
- **Added:** `TestAccessControlEntryFlag_Unmarshal_DeterministicEqual` in `ace/aceflags/AccessControlEntryFlags_order_test.go` — 1000-iteration stability check on a two-bit value plus an exact ordering assertion.

### Scope of Change
- **Files changed:** `ace/aceflags/AccessControlEntryFlags.go`, `ace/aceflags/AccessControlEntryFlags_order_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Ordering-only change; the set of reported flags is unchanged. Safe to merge.