### PR TITLE
[bug] Fix SDDL alias RO to map to Enterprise RODC RID 498 (Fixes #102)

### DIFF
--- a/sddl/sid/sid.go
+++ b/sddl/sid/sid.go
@@ -59,7 +59,7 @@ var SDDLToSID = map[string]string{
 	"SA": "S-1-5-21-0-0-0-518", // Schema Admins
 	"EA": "S-1-5-21-0-0-0-519", // Enterprise Admins
 	"PA": "S-1-5-21-0-0-0-520", // Group Policy Creator Owners
-	"RO": "S-1-5-21-0-0-0-521", // Read-Only Domain Controllers
+	"RO": "S-1-5-21-0-0-0-498", // Enterprise Read-Only Domain Controllers (SDDL_ENTERPRISE_RO_DCs)
 	"CN": "S-1-5-21-0-0-0-522", // Cloneable Domain Controllers
 	"RS": "S-1-5-21-0-0-0-553", // RAS Servers Group
 

--- a/sddl/sid/sid_test.go
+++ b/sddl/sid/sid_test.go
@@ -7,3 +7,28 @@ import (
 func TestSid(t *testing.T) {
 
 }
+
+// TestSDDLAlias_RO is a regression test for the SDDL alias "RO" mapping to the
+// wrong RID. Per the Microsoft SID Strings reference, "RO" is
+// SDDL_ENTERPRISE_RO_DCs (Enterprise Read-Only Domain Controllers),
+// DOMAIN_GROUP_RID_ENTERPRISE_READONLY_DOMAIN_CONTROLLERS = 498. It was
+// previously mapped to 521 (the plain Read-Only Domain Controllers group,
+// which has no SDDL alias).
+func TestSDDLAlias_RO(t *testing.T) {
+	const want = "S-1-5-21-0-0-0-498"
+
+	if got := SDDLToSID["RO"]; got != want {
+		t.Errorf("SDDLToSID[\"RO\"] = %q, want %q", got, want)
+	}
+
+	// The reverse mapping is derived from SDDLToSID, so it must resolve the
+	// correct SID back to "RO".
+	if got := SIDToSDDL[want]; got != "RO" {
+		t.Errorf("SIDToSDDL[%q] = %q, want \"RO\"", want, got)
+	}
+
+	// RID 521 must no longer be aliased to "RO".
+	if got, ok := SIDToSDDL["S-1-5-21-0-0-0-521"]; ok && got == "RO" {
+		t.Errorf("S-1-5-21-0-0-0-521 must not map to \"RO\" (it is the non-aliased Read-Only Domain Controllers group)")
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #102`

### Root Cause
The `SDDLToSID` table mapped the SDDL alias `"RO"` to `S-1-5-21-0-0-0-521`. Per the Microsoft SID Strings reference, `"RO"` is `SDDL_ENTERPRISE_RO_DCs` — the Enterprise Read-Only Domain Controllers group — whose RID is `DOMAIN_GROUP_RID_ENTERPRISE_READONLY_DOMAIN_CONTROLLERS` = 498. RID 521 is the separate plain Read-Only Domain Controllers group, which has no SDDL string constant. The RID was simply transcribed from the wrong group.

### Fix Description
Changed the `"RO"` entry to `S-1-5-21-0-0-0-498` and corrected the comment to "Enterprise Read-Only Domain Controllers (SDDL_ENTERPRISE_RO_DCs)". Because `SIDToSDDL` is built by inverting `SDDLToSID` in `init()`, both parse (`RO` → SID) and serialize (SID → `RO`) directions are corrected by this single change.

### How Verified
- **Static/authoritative:** cross-checked against the Microsoft SID Strings reference, which lists `"RO"` = `SDDL_ENTERPRISE_RO_DCs`, RID `DOMAIN_GROUP_RID_ENTERPRISE_READONLY_DOMAIN_CONTROLLERS` (498), and lists no alias for RID 521.
- **Tests:** `go test ./...` passes.

### Test Coverage
- **Added:** `TestSDDLAlias_RO` in `sddl/sid/sid_test.go` — asserts `SDDLToSID["RO"] == S-1-5-21-0-0-0-498`, that the reverse map resolves that SID back to `RO`, and that RID 521 is not aliased to `RO`.

### Scope of Change
- **Files changed:** `sddl/sid/sid.go`, `sddl/sid/sid_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none

### Risk and Rollout
Single data correction. Callers relying on the previous (incorrect) `RO`→521 mapping will now get the spec-correct 498. Safe to merge.