### PR TITLE
Support conditional-ACE expressions in SDDL conversion (Fixes #106)

### DIFF
--- a/ace/condition/condition.go
+++ b/ace/condition/condition.go
@@ -1,0 +1,289 @@
+// Package condition implements the conditional-expression codec used by
+// conditional (callback) ACEs, as specified in MS-DTYP 2.4.4.17 and its
+// subsections (2.4.4.17.1 Conditional ACE Expressions, and the Literal /
+// Attribute / Relational / Logical operator token tables).
+//
+// A conditional expression lives in the ApplicationData member of a callback
+// ACE, prefixed by the 4-byte ACE_CONDITION_SIGNATURE "artx" (0x61 0x72 0x74
+// 0x78). The remainder is a series of tokens in postfix (reverse Polish) order.
+// This package converts between the SDDL textual form of a conditional
+// expression (e.g. `(@User.Title=="PM" && @User.Division=="Finance")`) and that
+// binary form.
+//
+//	text -> Marshal   -> ApplicationData bytes ("artx" + tokens + DWORD padding)
+//	bytes -> Unmarshal -> text
+//
+// All multibyte integers (including UTF-16 characters) are stored
+// least-significant byte first, and the encoded expression is padded with 0x00
+// to a DWORD (4-byte) boundary.
+package condition
+
+import (
+	"fmt"
+)
+
+// ACE_CONDITION_SIGNATURE marks a callback ACE's ApplicationData as a
+// conditional expression (MS-DTYP 2.4.4.17.1).
+var ACE_CONDITION_SIGNATURE = []byte{0x61, 0x72, 0x74, 0x78}
+
+// Literal, attribute, and operator token byte-codes (MS-DTYP 2.4.4.17.1.x).
+const (
+	tokenPadding byte = 0x00
+
+	// Literal tokens.
+	tokenInt8      byte = 0x01
+	tokenInt16     byte = 0x02
+	tokenInt32     byte = 0x03
+	tokenInt64     byte = 0x04
+	tokenUnicode   byte = 0x10
+	tokenOctet     byte = 0x18
+	tokenComposite byte = 0x50
+	tokenSID       byte = 0x51
+
+	// Attribute-name tokens (encoding identical to a Unicode string).
+	tokenLocalAttr    byte = 0xf8
+	tokenUserAttr     byte = 0xf9
+	tokenResourceAttr byte = 0xfa
+	tokenDeviceAttr   byte = 0xfb
+
+	// Binary relational operators.
+	tokenEqual          byte = 0x80
+	tokenNotEqual       byte = 0x81
+	tokenLessThan       byte = 0x82
+	tokenLessOrEqual    byte = 0x83
+	tokenGreaterThan    byte = 0x84
+	tokenGreaterOrEqual byte = 0x85
+	tokenContains       byte = 0x86
+	tokenAnyOf          byte = 0x88
+	tokenNotContains    byte = 0x8e
+	tokenNotAnyOf       byte = 0x8f
+
+	// Unary relational operators (operand is a SID literal or a composite of SIDs).
+	tokenMemberOf             byte = 0x89
+	tokenDeviceMemberOf       byte = 0x8a
+	tokenMemberOfAny          byte = 0x8b
+	tokenDeviceMemberOfAny    byte = 0x8c
+	tokenNotMemberOf          byte = 0x90
+	tokenNotDeviceMemberOf    byte = 0x91
+	tokenNotMemberOfAny       byte = 0x92
+	tokenNotDeviceMemberOfAny byte = 0x93
+
+	// Unary logical operators.
+	tokenExists    byte = 0x87
+	tokenNotExists byte = 0x8d
+	tokenNot       byte = 0xa2
+
+	// Binary logical operators.
+	tokenAnd byte = 0xa0
+	tokenOr  byte = 0xa1
+)
+
+// Base codes for integer literals (MS-DTYP 2.4.4.17.5).
+const (
+	baseOctal   byte = 0x01
+	baseDecimal byte = 0x02
+	baseHex     byte = 0x03
+)
+
+// Sign codes for integer literals (MS-DTYP 2.4.4.17.5).
+const (
+	signPositive byte = 0x01
+	signNegative byte = 0x02
+	signNone     byte = 0x03
+)
+
+// wordOperators maps the SDDL keyword operators to their token byte-codes.
+var wordOperators = map[string]byte{
+	"Contains":                 tokenContains,
+	"Not_Contains":             tokenNotContains,
+	"Any_of":                   tokenAnyOf,
+	"Not_Any_of":               tokenNotAnyOf,
+	"Member_of":                tokenMemberOf,
+	"Device_Member_of":         tokenDeviceMemberOf,
+	"Member_of_Any":            tokenMemberOfAny,
+	"Device_Member_of_Any":     tokenDeviceMemberOfAny,
+	"Not_Member_of":            tokenNotMemberOf,
+	"Not_Device_Member_of":     tokenNotDeviceMemberOf,
+	"Not_Member_of_Any":        tokenNotMemberOfAny,
+	"Not_Device_Member_of_Any": tokenNotDeviceMemberOfAny,
+	"Exists":                   tokenExists,
+	"Not_Exists":               tokenNotExists,
+}
+
+// operatorNames is the reverse of wordOperators plus the symbolic operators,
+// used when serializing an AST back to SDDL text.
+var operatorNames = map[byte]string{
+	tokenAnd:                  "&&",
+	tokenOr:                   "||",
+	tokenNot:                  "!",
+	tokenEqual:                "==",
+	tokenNotEqual:             "!=",
+	tokenLessThan:             "<",
+	tokenLessOrEqual:          "<=",
+	tokenGreaterThan:          ">",
+	tokenGreaterOrEqual:       ">=",
+	tokenContains:             "Contains",
+	tokenNotContains:          "Not_Contains",
+	tokenAnyOf:                "Any_of",
+	tokenNotAnyOf:             "Not_Any_of",
+	tokenMemberOf:             "Member_of",
+	tokenDeviceMemberOf:       "Device_Member_of",
+	tokenMemberOfAny:          "Member_of_Any",
+	tokenDeviceMemberOfAny:    "Device_Member_of_Any",
+	tokenNotMemberOf:          "Not_Member_of",
+	tokenNotDeviceMemberOf:    "Not_Device_Member_of",
+	tokenNotMemberOfAny:       "Not_Member_of_Any",
+	tokenNotDeviceMemberOfAny: "Not_Device_Member_of_Any",
+	tokenExists:               "Exists",
+	tokenNotExists:            "Not_Exists",
+}
+
+func isMemberOfOperator(tok byte) bool {
+	switch tok {
+	case tokenMemberOf, tokenDeviceMemberOf, tokenMemberOfAny, tokenDeviceMemberOfAny,
+		tokenNotMemberOf, tokenNotDeviceMemberOf, tokenNotMemberOfAny, tokenNotDeviceMemberOfAny:
+		return true
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// Abstract syntax tree
+// ---------------------------------------------------------------------------
+
+// Node is a node in a conditional-expression AST.
+type Node interface {
+	isNode()
+}
+
+// Attribute is an attribute-name operand (local or @User./@Resource./@Device.).
+type Attribute struct {
+	Token byte // one of tokenLocalAttr/tokenUserAttr/tokenResourceAttr/tokenDeviceAttr
+	Name  string
+}
+
+// IntLiteral is an integer literal. Width is the token byte-code (int8..int64),
+// Base and Sign preserve the textual representation for lossless round-tripping.
+type IntLiteral struct {
+	Value int64
+	Width byte
+	Base  byte
+	Sign  byte
+}
+
+// StringLiteral is a Unicode string literal.
+type StringLiteral struct{ Value string }
+
+// OctetLiteral is an octet (byte) string literal (SDDL "#hex" form).
+type OctetLiteral struct{ Value []byte }
+
+// SIDLiteral is a SID literal (SDDL "SID(...)" form).
+type SIDLiteral struct{ SID string }
+
+// Composite is a braced set of literals ("{a,b,c}").
+type Composite struct{ Items []Node }
+
+// UnaryOp applies a unary operator (logical !, Exists/Not_Exists, or a
+// Member_of-family operator) to a single operand.
+type UnaryOp struct {
+	Op      byte
+	Operand Node
+}
+
+// BinaryOp applies a binary operator (relational or logical) to two operands.
+type BinaryOp struct {
+	Op          byte
+	Left, Right Node
+}
+
+func (*Attribute) isNode()     {}
+func (*IntLiteral) isNode()    {}
+func (*StringLiteral) isNode() {}
+func (*OctetLiteral) isNode()  {}
+func (*SIDLiteral) isNode()    {}
+func (*Composite) isNode()     {}
+func (*UnaryOp) isNode()       {}
+func (*BinaryOp) isNode()      {}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+// IsConditional reports whether applicationData carries a conditional
+// expression, i.e. whether it begins with the ACE_CONDITION_SIGNATURE.
+func IsConditional(applicationData []byte) bool {
+	return len(applicationData) >= 4 &&
+		applicationData[0] == ACE_CONDITION_SIGNATURE[0] &&
+		applicationData[1] == ACE_CONDITION_SIGNATURE[1] &&
+		applicationData[2] == ACE_CONDITION_SIGNATURE[2] &&
+		applicationData[3] == ACE_CONDITION_SIGNATURE[3]
+}
+
+// Marshal parses an SDDL conditional-expression string and returns the binary
+// ApplicationData encoding (signature + postfix token stream + DWORD padding).
+// The input may optionally be wrapped in a single outer pair of parentheses, as
+// it appears in an ACE string.
+func Marshal(expr string) ([]byte, error) {
+	root, err := Parse(expr)
+	if err != nil {
+		return nil, err
+	}
+	return Encode(root)
+}
+
+// Unmarshal decodes binary conditional-expression ApplicationData into its SDDL
+// textual form (without an outer pair of parentheses).
+func Unmarshal(applicationData []byte) (string, error) {
+	root, err := Decode(applicationData)
+	if err != nil {
+		return "", err
+	}
+	return Serialize(root), nil
+}
+
+// Parse converts an SDDL conditional-expression string into an AST.
+func Parse(expr string) (Node, error) {
+	toks, err := lex(expr)
+	if err != nil {
+		return nil, err
+	}
+	p := &parser{tokens: toks}
+	node, err := p.parseExpr()
+	if err != nil {
+		return nil, err
+	}
+	if !p.atEnd() {
+		return nil, fmt.Errorf("unexpected trailing input at token %q", p.peek().text)
+	}
+	return node, nil
+}
+
+// Encode serializes an AST into binary ApplicationData.
+func Encode(root Node) ([]byte, error) {
+	out := make([]byte, 0, 32)
+	out = append(out, ACE_CONDITION_SIGNATURE...)
+	body, err := encodeNode(root)
+	if err != nil {
+		return nil, err
+	}
+	out = append(out, body...)
+	// Pad to a DWORD boundary with 0x00.
+	for len(out)%4 != 0 {
+		out = append(out, 0x00)
+	}
+	return out, nil
+}
+
+// Decode parses binary ApplicationData into an AST.
+func Decode(data []byte) (Node, error) {
+	if !IsConditional(data) {
+		return nil, fmt.Errorf("application data is not a conditional expression (missing artx signature)")
+	}
+	return decodeTokens(data[4:])
+}
+
+// Serialize converts an AST back into an SDDL conditional-expression string
+// (without an outer pair of parentheses).
+func Serialize(root Node) string {
+	return serializeNode(root, 0)
+}

--- a/ace/condition/condition_test.go
+++ b/ace/condition/condition_test.go
@@ -1,0 +1,124 @@
+package condition_test
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/TheManticoreProject/winacl/ace/condition"
+)
+
+// TestMarshal_KnownAnswer validates the encoder against the exact byte sequence
+// from MS-DTYP 2.4.4.17.2 Example 1 for the conditional expression (Title=="VP").
+func TestMarshal_KnownAnswer(t *testing.T) {
+	const expr = `(Title=="VP")`
+	// artx | f8 local-attr len=10 "Title" | 10 unicode len=4 "VP" | 80 == | 00 00 00 pad
+	want := "61727478" +
+		"f80a000000" + "540069007400 6c006500" +
+		"10" + "04000000" + "560050 00" +
+		"80" +
+		"000000"
+	want = strings.ReplaceAll(want, " ", "")
+
+	got, err := condition.Marshal(expr)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	if gotHex := hex.EncodeToString(got); gotHex != want {
+		t.Fatalf("Marshal(%q) =\n  %s\nwant\n  %s", expr, gotHex, want)
+	}
+	if len(got)%4 != 0 {
+		t.Fatalf("encoded length %d is not DWORD-aligned", len(got))
+	}
+}
+
+// TestUnmarshal_KnownAnswer validates the decoder against the same example.
+func TestUnmarshal_KnownAnswer(t *testing.T) {
+	raw, _ := hex.DecodeString("61727478f80a000000540069007400" + "6c006500" + "1004000000560050008000" + "0000")
+	got, err := condition.Unmarshal(raw)
+	if err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if got != `Title == "VP"` {
+		t.Fatalf("Unmarshal() = %q, want %q", got, `Title == "VP"`)
+	}
+}
+
+// TestRoundTrip_Binary verifies that Marshal->Unmarshal->Marshal is stable for a
+// range of expressions covering every operator/literal/attribute form.
+func TestRoundTrip_Binary(t *testing.T) {
+	exprs := []string{
+		`(Title=="VP")`,
+		`(@User.Title=="PM")`,
+		`(@User.Title=="PM" && @User.Division=="Finance")`,
+		`(@User.Title=="PM" && (@User.Division=="Finance" || @User.Division=="Sales"))`,
+		`(@User.smartcard==1 || @Device.managed==1)`,
+		`(@Resource.dept Any_of {"Sales", "HR"})`,
+		`(@User.clearanceLevel>=@Resource.requiredClearance)`,
+		`(Member_of {SID(BA)})`,
+		`(Member_of {SID(BA), SID(WD)})`,
+		`(Not_Member_of_Any {SID(BA)})`,
+		`(Exists @User.Title)`,
+		`(Not_Exists @User.Title)`,
+		`(!(@User.Title=="PM"))`,
+		`(@User.count>=-5)`,
+		`(@User.count==0x1f)`,
+		`(@User.blob==#01ff2a)`,
+		`(@User.dept Contains "Sales")`,
+		`(@User.dept != {1, 2, 3})`,
+	}
+
+	for _, expr := range exprs {
+		t.Run(expr, func(t *testing.T) {
+			bin1, err := condition.Marshal(expr)
+			if err != nil {
+				t.Fatalf("Marshal(%q) error = %v", expr, err)
+			}
+			if !condition.IsConditional(bin1) {
+				t.Fatalf("encoded data lacks the artx signature")
+			}
+			text, err := condition.Unmarshal(bin1)
+			if err != nil {
+				t.Fatalf("Unmarshal error = %v", err)
+			}
+			bin2, err := condition.Marshal(text)
+			if err != nil {
+				t.Fatalf("re-Marshal(%q) error = %v", text, err)
+			}
+			if hex.EncodeToString(bin1) != hex.EncodeToString(bin2) {
+				t.Fatalf("binary round-trip not stable for %q:\n  first:  %x\n  via %q\n  second: %x", expr, bin1, text, bin2)
+			}
+		})
+	}
+}
+
+// TestParseErrors verifies malformed expressions are rejected.
+func TestParseErrors(t *testing.T) {
+	bad := []string{
+		`(@User.Title ==)`,
+		`(&& @User.Title=="x")`,
+		`(@User.Title == "unterminated)`,
+		`(Member_of SID(BA))`, // Member_of requires a brace array
+		`()`,
+	}
+	for _, expr := range bad {
+		t.Run(expr, func(t *testing.T) {
+			if _, err := condition.Marshal(expr); err == nil {
+				t.Fatalf("Marshal(%q) expected an error, got nil", expr)
+			}
+		})
+	}
+}
+
+// TestIsConditional checks signature detection.
+func TestIsConditional(t *testing.T) {
+	if condition.IsConditional([]byte{0x00, 0x01, 0x02, 0x03}) {
+		t.Error("non-artx data reported as conditional")
+	}
+	if !condition.IsConditional([]byte("artx....")) {
+		t.Error("artx data not reported as conditional")
+	}
+	if condition.IsConditional([]byte{0x61, 0x72}) {
+		t.Error("short data reported as conditional")
+	}
+}

--- a/ace/condition/decode.go
+++ b/ace/condition/decode.go
@@ -1,0 +1,198 @@
+package condition
+
+import (
+	"encoding/binary"
+	"fmt"
+	"unicode/utf16"
+
+	"github.com/TheManticoreProject/winacl/sid"
+)
+
+// decodeTokens runs the postfix token stream (without the artx signature)
+// through a stack machine and returns the reconstructed AST.
+func decodeTokens(data []byte) (Node, error) {
+	var stack []Node
+	pop := func() (Node, error) {
+		if len(stack) == 0 {
+			return nil, fmt.Errorf("conditional expression underflow: operator with no operand")
+		}
+		n := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		return n, nil
+	}
+
+	i := 0
+	for i < len(data) {
+		tok := data[i]
+		if tok == tokenPadding {
+			// Trailing DWORD padding; nothing else follows.
+			break
+		}
+		node, n, err := decodeToken(data[i:])
+		if err != nil {
+			return nil, err
+		}
+		if node != nil {
+			// Literal / attribute / composite operand.
+			stack = append(stack, node)
+			i += n
+			continue
+		}
+
+		// Operator token (single byte).
+		switch {
+		case isUnaryOperator(tok):
+			operand, err := pop()
+			if err != nil {
+				return nil, err
+			}
+			stack = append(stack, &UnaryOp{Op: tok, Operand: operand})
+		case isBinaryOperator(tok):
+			right, err := pop()
+			if err != nil {
+				return nil, err
+			}
+			left, err := pop()
+			if err != nil {
+				return nil, err
+			}
+			stack = append(stack, &BinaryOp{Op: tok, Left: left, Right: right})
+		default:
+			return nil, fmt.Errorf("unknown conditional-expression token 0x%02x", tok)
+		}
+		i++
+	}
+
+	if len(stack) != 1 {
+		return nil, fmt.Errorf("malformed conditional expression: %d values left on the stack", len(stack))
+	}
+	return stack[0], nil
+}
+
+// decodeToken decodes a single operand token at the start of data. It returns
+// (nil, 0, nil) when the leading byte is an operator (handled by the caller).
+func decodeToken(data []byte) (Node, int, error) {
+	tok := data[0]
+	switch tok {
+	case tokenInt8, tokenInt16, tokenInt32, tokenInt64:
+		if len(data) < 11 {
+			return nil, 0, fmt.Errorf("truncated integer literal")
+		}
+		value := int64(binary.LittleEndian.Uint64(data[1:9]))
+		sign := data[9]
+		base := data[10]
+		return &IntLiteral{Value: value, Width: tok, Sign: sign, Base: base}, 11, nil
+
+	case tokenUnicode:
+		s, n, err := decodeUTF16LenPrefixed(data[1:])
+		if err != nil {
+			return nil, 0, err
+		}
+		return &StringLiteral{Value: s}, 1 + n, nil
+
+	case tokenOctet:
+		if len(data) < 5 {
+			return nil, 0, fmt.Errorf("truncated octet string")
+		}
+		l := int(binary.LittleEndian.Uint32(data[1:5]))
+		if 5+l > len(data) {
+			return nil, 0, fmt.Errorf("octet string length %d exceeds available data", l)
+		}
+		b := make([]byte, l)
+		copy(b, data[5:5+l])
+		return &OctetLiteral{Value: b}, 5 + l, nil
+
+	case tokenSID:
+		if len(data) < 5 {
+			return nil, 0, fmt.Errorf("truncated SID literal")
+		}
+		l := int(binary.LittleEndian.Uint32(data[1:5]))
+		if 5+l > len(data) {
+			return nil, 0, fmt.Errorf("SID literal length %d exceeds available data", l)
+		}
+		sd := &sid.SID{}
+		if _, err := sd.Unmarshal(data[5 : 5+l]); err != nil {
+			return nil, 0, fmt.Errorf("invalid SID literal: %w", err)
+		}
+		return &SIDLiteral{SID: sd.ToString()}, 5 + l, nil
+
+	case tokenComposite:
+		if len(data) < 5 {
+			return nil, 0, fmt.Errorf("truncated composite literal")
+		}
+		l := int(binary.LittleEndian.Uint32(data[1:5]))
+		if 5+l > len(data) {
+			return nil, 0, fmt.Errorf("composite length %d exceeds available data", l)
+		}
+		items, err := decodeComposite(data[5 : 5+l])
+		if err != nil {
+			return nil, 0, err
+		}
+		return &Composite{Items: items}, 5 + l, nil
+
+	case tokenLocalAttr, tokenUserAttr, tokenResourceAttr, tokenDeviceAttr:
+		s, n, err := decodeUTF16LenPrefixed(data[1:])
+		if err != nil {
+			return nil, 0, err
+		}
+		return &Attribute{Token: tok, Name: s}, 1 + n, nil
+	}
+
+	// Not an operand token; leave it for the caller's operator handling.
+	return nil, 0, nil
+}
+
+// decodeComposite decodes the concatenated literal tokens inside a composite.
+func decodeComposite(data []byte) ([]Node, error) {
+	var items []Node
+	i := 0
+	for i < len(data) {
+		node, n, err := decodeToken(data[i:])
+		if err != nil {
+			return nil, err
+		}
+		if node == nil {
+			return nil, fmt.Errorf("unexpected operator token 0x%02x inside composite", data[i])
+		}
+		items = append(items, node)
+		i += n
+	}
+	return items, nil
+}
+
+// decodeUTF16LenPrefixed reads a DWORD byte-length followed by UTF-16LE units.
+func decodeUTF16LenPrefixed(data []byte) (string, int, error) {
+	if len(data) < 4 {
+		return "", 0, fmt.Errorf("truncated length-prefixed string")
+	}
+	l := int(binary.LittleEndian.Uint32(data[0:4]))
+	if l%2 != 0 {
+		return "", 0, fmt.Errorf("length-prefixed string has odd byte length %d", l)
+	}
+	if 4+l > len(data) {
+		return "", 0, fmt.Errorf("string length %d exceeds available data", l)
+	}
+	u16 := make([]uint16, l/2)
+	for j := 0; j < l/2; j++ {
+		u16[j] = binary.LittleEndian.Uint16(data[4+j*2 : 4+j*2+2])
+	}
+	return string(utf16.Decode(u16)), 4 + l, nil
+}
+
+func isUnaryOperator(tok byte) bool {
+	switch tok {
+	case tokenNot, tokenExists, tokenNotExists:
+		return true
+	}
+	return isMemberOfOperator(tok)
+}
+
+func isBinaryOperator(tok byte) bool {
+	switch tok {
+	case tokenEqual, tokenNotEqual, tokenLessThan, tokenLessOrEqual, tokenGreaterThan,
+		tokenGreaterOrEqual, tokenContains, tokenAnyOf, tokenNotContains, tokenNotAnyOf,
+		tokenAnd, tokenOr:
+		return true
+	}
+	return false
+}

--- a/ace/condition/encode.go
+++ b/ace/condition/encode.go
@@ -1,0 +1,122 @@
+package condition
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strings"
+	"unicode/utf16"
+
+	sddl_sid "github.com/TheManticoreProject/winacl/sddl/sid"
+	"github.com/TheManticoreProject/winacl/sid"
+)
+
+// encodeNode emits a node in postfix order.
+func encodeNode(n Node) ([]byte, error) {
+	switch v := n.(type) {
+	case *Attribute:
+		out := []byte{v.Token}
+		out = append(out, encodeUTF16LenPrefixed(v.Name)...)
+		return out, nil
+
+	case *IntLiteral:
+		out := make([]byte, 0, 11)
+		out = append(out, v.Width)
+		var q [8]byte
+		binary.LittleEndian.PutUint64(q[:], uint64(v.Value))
+		out = append(out, q[:]...)
+		out = append(out, v.Sign, v.Base)
+		return out, nil
+
+	case *StringLiteral:
+		out := []byte{tokenUnicode}
+		out = append(out, encodeUTF16LenPrefixed(v.Value)...)
+		return out, nil
+
+	case *OctetLiteral:
+		out := []byte{tokenOctet}
+		var l [4]byte
+		binary.LittleEndian.PutUint32(l[:], uint32(len(v.Value)))
+		out = append(out, l[:]...)
+		out = append(out, v.Value...)
+		return out, nil
+
+	case *SIDLiteral:
+		sidBytes, err := encodeSID(v.SID)
+		if err != nil {
+			return nil, err
+		}
+		out := []byte{tokenSID}
+		var l [4]byte
+		binary.LittleEndian.PutUint32(l[:], uint32(len(sidBytes)))
+		out = append(out, l[:]...)
+		out = append(out, sidBytes...)
+		return out, nil
+
+	case *Composite:
+		var body []byte
+		for _, item := range v.Items {
+			b, err := encodeNode(item)
+			if err != nil {
+				return nil, err
+			}
+			body = append(body, b...)
+		}
+		out := []byte{tokenComposite}
+		var l [4]byte
+		binary.LittleEndian.PutUint32(l[:], uint32(len(body)))
+		out = append(out, l[:]...)
+		out = append(out, body...)
+		return out, nil
+
+	case *UnaryOp:
+		operand, err := encodeNode(v.Operand)
+		if err != nil {
+			return nil, err
+		}
+		return append(operand, v.Op), nil
+
+	case *BinaryOp:
+		left, err := encodeNode(v.Left)
+		if err != nil {
+			return nil, err
+		}
+		right, err := encodeNode(v.Right)
+		if err != nil {
+			return nil, err
+		}
+		out := append(left, right...)
+		return append(out, v.Op), nil
+	}
+	return nil, fmt.Errorf("cannot encode conditional-expression node of type %T", n)
+}
+
+// encodeUTF16LenPrefixed encodes s as a DWORD byte-length followed by the
+// UTF-16LE code units (no NUL terminator), as used by both Unicode string
+// literals and attribute-name tokens.
+func encodeUTF16LenPrefixed(s string) []byte {
+	u16 := utf16.Encode([]rune(s))
+	out := make([]byte, 4, 4+len(u16)*2)
+	binary.LittleEndian.PutUint32(out, uint32(len(u16)*2))
+	for _, c := range u16 {
+		var b [2]byte
+		binary.LittleEndian.PutUint16(b[:], c)
+		out = append(out, b[:]...)
+	}
+	return out
+}
+
+// encodeSID resolves an SDDL SID alias or S-string and returns its binary form.
+func encodeSID(s string) ([]byte, error) {
+	resolved := s
+	if full, ok := sddl_sid.SDDLToSID[strings.TrimSpace(s)]; ok {
+		resolved = full
+	}
+	if !strings.HasPrefix(resolved, "S-") {
+		return nil, fmt.Errorf("unknown SID %q in conditional expression", s)
+	}
+	sd := &sid.SID{}
+	if err := sd.FromString(resolved); err != nil {
+		return nil, fmt.Errorf("invalid SID %q: %w", s, err)
+	}
+	return sd.Marshal()
+}

--- a/ace/condition/parser.go
+++ b/ace/condition/parser.go
@@ -1,0 +1,504 @@
+package condition
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// ---------------------------------------------------------------------------
+// Lexer
+// ---------------------------------------------------------------------------
+
+type tokKind int
+
+const (
+	tkWord tokKind = iota // attribute name or keyword operator
+	tkString
+	tkInt
+	tkOctet
+	tkSymbol // ( ) { } , == != < <= > >= && || !
+)
+
+type lexToken struct {
+	kind tokKind
+	text string
+}
+
+func isWordByte(b byte) bool {
+	// attr-char1 plus '@' and '.' so a full @Prefixed name lexes as one word,
+	// and '-' so a SID string (e.g. S-1-5-32-544) inside SID(...) is a single
+	// word. A leading '-' is still lexed as an integer sign because the integer
+	// case is matched before the word case.
+	return (b >= 'A' && b <= 'Z') || (b >= 'a' && b <= 'z') ||
+		(b >= '0' && b <= '9') || b == ':' || b == '.' || b == '/' || b == '_' || b == '@' || b == '-'
+}
+
+func lex(s string) ([]lexToken, error) {
+	var toks []lexToken
+	i := 0
+	for i < len(s) {
+		c := s[i]
+		switch {
+		case c == ' ' || c == '\t' || c == '\r' || c == '\n':
+			i++
+		case c == '(' || c == ')' || c == '{' || c == '}' || c == ',':
+			toks = append(toks, lexToken{tkSymbol, string(c)})
+			i++
+		case c == '"':
+			// String literal: read to the closing quote (no escaping is defined).
+			j := i + 1
+			for j < len(s) && s[j] != '"' {
+				j++
+			}
+			if j >= len(s) {
+				return nil, fmt.Errorf("unterminated string literal")
+			}
+			toks = append(toks, lexToken{tkString, s[i+1 : j]})
+			i = j + 1
+		case c == '#':
+			// Octet string: '#' followed by hex digit pairs.
+			j := i + 1
+			for j < len(s) && isHexDigit(s[j]) {
+				j++
+			}
+			toks = append(toks, lexToken{tkOctet, s[i:j]})
+			i = j
+		case c == '=' || c == '!' || c == '<' || c == '>' || c == '&' || c == '|':
+			sym, n, err := lexSymbolOperator(s[i:])
+			if err != nil {
+				return nil, err
+			}
+			toks = append(toks, lexToken{tkSymbol, sym})
+			i += n
+		case c == '+' || c == '-' || (c >= '0' && c <= '9'):
+			// Integer literal (optionally signed).
+			j := i
+			if s[j] == '+' || s[j] == '-' {
+				j++
+			}
+			for j < len(s) && (isAlnum(s[j])) {
+				j++
+			}
+			toks = append(toks, lexToken{tkInt, s[i:j]})
+			i = j
+		case isWordByte(c):
+			j := i
+			for j < len(s) && isWordByte(s[j]) {
+				j++
+			}
+			toks = append(toks, lexToken{tkWord, s[i:j]})
+			i = j
+		default:
+			return nil, fmt.Errorf("unexpected character %q in conditional expression", c)
+		}
+	}
+	return toks, nil
+}
+
+func lexSymbolOperator(s string) (string, int, error) {
+	switch {
+	case strings.HasPrefix(s, "=="):
+		return "==", 2, nil
+	case strings.HasPrefix(s, "!="):
+		return "!=", 2, nil
+	case strings.HasPrefix(s, "<="):
+		return "<=", 2, nil
+	case strings.HasPrefix(s, ">="):
+		return ">=", 2, nil
+	case strings.HasPrefix(s, "&&"):
+		return "&&", 2, nil
+	case strings.HasPrefix(s, "||"):
+		return "||", 2, nil
+	case s[0] == '<':
+		return "<", 1, nil
+	case s[0] == '>':
+		return ">", 1, nil
+	case s[0] == '!':
+		return "!", 1, nil
+	}
+	return "", 0, fmt.Errorf("invalid operator near %q", s)
+}
+
+func isHexDigit(b byte) bool {
+	return (b >= '0' && b <= '9') || (b >= 'a' && b <= 'f') || (b >= 'A' && b <= 'F')
+}
+
+func isAlnum(b byte) bool {
+	return (b >= '0' && b <= '9') || (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z')
+}
+
+// ---------------------------------------------------------------------------
+// Recursive-descent parser (precedence: || < && < unary/relational/atom)
+// ---------------------------------------------------------------------------
+
+type parser struct {
+	tokens []lexToken
+	pos    int
+}
+
+func (p *parser) atEnd() bool { return p.pos >= len(p.tokens) }
+func (p *parser) peek() lexToken {
+	if p.atEnd() {
+		return lexToken{}
+	}
+	return p.tokens[p.pos]
+}
+func (p *parser) next() lexToken { t := p.peek(); p.pos++; return t }
+func (p *parser) isSymbol(s string) bool {
+	t := p.peek()
+	return !p.atEnd() && t.kind == tkSymbol && t.text == s
+}
+
+// expr = super-term *( "||" super-term )
+func (p *parser) parseExpr() (Node, error) {
+	left, err := p.parseSuperTerm()
+	if err != nil {
+		return nil, err
+	}
+	for p.isSymbol("||") {
+		p.next()
+		right, err := p.parseSuperTerm()
+		if err != nil {
+			return nil, err
+		}
+		left = &BinaryOp{Op: tokenOr, Left: left, Right: right}
+	}
+	return left, nil
+}
+
+// super-term = factor *( "&&" factor )
+func (p *parser) parseSuperTerm() (Node, error) {
+	left, err := p.parseFactor()
+	if err != nil {
+		return nil, err
+	}
+	for p.isSymbol("&&") {
+		p.next()
+		right, err := p.parseFactor()
+		if err != nil {
+			return nil, err
+		}
+		left = &BinaryOp{Op: tokenAnd, Left: left, Right: right}
+	}
+	return left, nil
+}
+
+// factor = "(" expr ")" | "!" factor | term
+func (p *parser) parseFactor() (Node, error) {
+	if p.isSymbol("(") {
+		p.next()
+		node, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		if !p.isSymbol(")") {
+			return nil, fmt.Errorf("expected ')' to close parenthesized expression")
+		}
+		p.next()
+		return node, nil
+	}
+	if p.isSymbol("!") {
+		p.next()
+		operand, err := p.parseFactor()
+		if err != nil {
+			return nil, err
+		}
+		return &UnaryOp{Op: tokenNot, Operand: operand}, nil
+	}
+	return p.parseTerm()
+}
+
+// term = memberof-op sid-array | exists-op attr | attr [rel-op rhs]
+func (p *parser) parseTerm() (Node, error) {
+	t := p.peek()
+	if p.atEnd() {
+		return nil, fmt.Errorf("unexpected end of conditional expression")
+	}
+
+	if t.kind == tkWord {
+		if op, ok := wordOperators[t.text]; ok {
+			// Leading keyword operator: Member_of family or Exists/Not_Exists.
+			p.next()
+			if isMemberOfOperator(op) {
+				operand, err := p.parseSidArray()
+				if err != nil {
+					return nil, err
+				}
+				return &UnaryOp{Op: op, Operand: operand}, nil
+			}
+			if op == tokenExists || op == tokenNotExists {
+				attr, err := p.parseAttribute()
+				if err != nil {
+					return nil, err
+				}
+				return &UnaryOp{Op: op, Operand: attr}, nil
+			}
+			return nil, fmt.Errorf("operator %q cannot begin a term", t.text)
+		}
+	}
+
+	// Otherwise the term begins with an attribute name (LHS).
+	lhs, err := p.parseAttribute()
+	if err != nil {
+		return nil, err
+	}
+
+	// An optional relational operator + RHS follows; otherwise the attribute is
+	// a standalone term (evaluated for its logical value).
+	op, ok := p.peekRelationalOperator()
+	if !ok {
+		return lhs, nil
+	}
+	p.consumeRelationalOperator()
+	rhs, err := p.parseRHS()
+	if err != nil {
+		return nil, err
+	}
+	return &BinaryOp{Op: op, Left: lhs, Right: rhs}, nil
+}
+
+// peekRelationalOperator reports the token code of an upcoming relational
+// operator (symbolic or keyword) without consuming it.
+func (p *parser) peekRelationalOperator() (byte, bool) {
+	t := p.peek()
+	if p.atEnd() {
+		return 0, false
+	}
+	if t.kind == tkSymbol {
+		switch t.text {
+		case "==":
+			return tokenEqual, true
+		case "!=":
+			return tokenNotEqual, true
+		case "<":
+			return tokenLessThan, true
+		case "<=":
+			return tokenLessOrEqual, true
+		case ">":
+			return tokenGreaterThan, true
+		case ">=":
+			return tokenGreaterOrEqual, true
+		}
+		return 0, false
+	}
+	if t.kind == tkWord {
+		switch t.text {
+		case "Contains":
+			return tokenContains, true
+		case "Not_Contains":
+			return tokenNotContains, true
+		case "Any_of":
+			return tokenAnyOf, true
+		case "Not_Any_of":
+			return tokenNotAnyOf, true
+		}
+	}
+	return 0, false
+}
+
+func (p *parser) consumeRelationalOperator() { p.next() }
+
+// parseRHS parses the right-hand side of a binary relational operator: an
+// @Prefixed attribute, a value-array ("{a,b}"), or a single value.
+func (p *parser) parseRHS() (Node, error) {
+	t := p.peek()
+	if p.atEnd() {
+		return nil, fmt.Errorf("expected right-hand-side operand")
+	}
+	if t.kind == tkWord && strings.HasPrefix(t.text, "@") {
+		return p.parseAttribute()
+	}
+	if p.isSymbol("{") {
+		return p.parseComposite()
+	}
+	return p.parseValue()
+}
+
+// parseComposite parses "{ value , value , ... }" into a Composite.
+func (p *parser) parseComposite() (Node, error) {
+	if !p.isSymbol("{") {
+		return nil, fmt.Errorf("expected '{' to begin a value set")
+	}
+	p.next()
+	c := &Composite{}
+	for {
+		v, err := p.parseValue()
+		if err != nil {
+			return nil, err
+		}
+		c.Items = append(c.Items, v)
+		if p.isSymbol(",") {
+			p.next()
+			continue
+		}
+		break
+	}
+	if !p.isSymbol("}") {
+		return nil, fmt.Errorf("expected '}' to close a value set")
+	}
+	p.next()
+	return c, nil
+}
+
+// parseSidArray parses a Member_of operand: "{ SID(..) , SID(..) }".
+func (p *parser) parseSidArray() (Node, error) {
+	if !p.isSymbol("{") {
+		return nil, fmt.Errorf("expected '{' to begin a SID array")
+	}
+	p.next()
+	c := &Composite{}
+	for {
+		s, err := p.parseSidLiteral()
+		if err != nil {
+			return nil, err
+		}
+		c.Items = append(c.Items, s)
+		if p.isSymbol(",") {
+			p.next()
+			continue
+		}
+		break
+	}
+	if !p.isSymbol("}") {
+		return nil, fmt.Errorf("expected '}' to close a SID array")
+	}
+	p.next()
+	return c, nil
+}
+
+// parseValue parses a single literal: SID(...), string, octet, or integer.
+func (p *parser) parseValue() (Node, error) {
+	t := p.peek()
+	if p.atEnd() {
+		return nil, fmt.Errorf("expected a literal value")
+	}
+	switch t.kind {
+	case tkString:
+		p.next()
+		return &StringLiteral{Value: t.text}, nil
+	case tkOctet:
+		p.next()
+		return parseOctet(t.text)
+	case tkInt:
+		p.next()
+		return parseInt(t.text)
+	case tkWord:
+		if t.text == "SID" {
+			return p.parseSidLiteral()
+		}
+	}
+	return nil, fmt.Errorf("unexpected token %q where a literal value was expected", t.text)
+}
+
+// parseSidLiteral parses "SID( sid-string )".
+func (p *parser) parseSidLiteral() (Node, error) {
+	t := p.next()
+	if t.kind != tkWord || t.text != "SID" {
+		return nil, fmt.Errorf("expected 'SID(' literal, got %q", t.text)
+	}
+	if !p.isSymbol("(") {
+		return nil, fmt.Errorf("expected '(' after SID")
+	}
+	p.next()
+	inner := p.peek()
+	if inner.kind != tkWord {
+		return nil, fmt.Errorf("expected a SID inside SID(...)")
+	}
+	p.next()
+	if !p.isSymbol(")") {
+		return nil, fmt.Errorf("expected ')' to close SID(...)")
+	}
+	p.next()
+	return &SIDLiteral{SID: inner.text}, nil
+}
+
+// parseAttribute parses an attribute name (local or @Prefixed) into an Attribute.
+func (p *parser) parseAttribute() (Node, error) {
+	t := p.peek()
+	if p.atEnd() || t.kind != tkWord {
+		return nil, fmt.Errorf("expected an attribute name")
+	}
+	p.next()
+	name := t.text
+	lower := strings.ToLower(name)
+	switch {
+	case strings.HasPrefix(lower, "@user."):
+		return &Attribute{Token: tokenUserAttr, Name: name[len("@user."):]}, nil
+	case strings.HasPrefix(lower, "@device."):
+		return &Attribute{Token: tokenDeviceAttr, Name: name[len("@device."):]}, nil
+	case strings.HasPrefix(lower, "@resource."):
+		return &Attribute{Token: tokenResourceAttr, Name: name[len("@resource."):]}, nil
+	case strings.HasPrefix(name, "@"):
+		return nil, fmt.Errorf("unknown attribute prefix in %q", name)
+	default:
+		return &Attribute{Token: tokenLocalAttr, Name: name}, nil
+	}
+}
+
+// parseInt parses an SDDL int-64 literal, recording its base and sign so the
+// binary encoding round-trips.
+func parseInt(s string) (Node, error) {
+	sign := signNone
+	body := s
+	if strings.HasPrefix(body, "+") {
+		sign = signPositive
+		body = body[1:]
+	} else if strings.HasPrefix(body, "-") {
+		sign = signNegative
+		body = body[1:]
+	}
+
+	base := baseDecimal
+	var value int64
+	var err error
+	switch {
+	case strings.HasPrefix(body, "0x") || strings.HasPrefix(body, "0X"):
+		base = baseHex
+		value, err = strconv.ParseInt(body[2:], 16, 64)
+	case len(body) > 1 && body[0] == '0':
+		base = baseOctal
+		value, err = strconv.ParseInt(body[1:], 8, 64)
+	default:
+		value, err = strconv.ParseInt(body, 10, 64)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("invalid integer literal %q: %w", s, err)
+	}
+	if sign == signNegative {
+		value = -value
+	}
+
+	return &IntLiteral{Value: value, Width: intWidth(value), Base: base, Sign: sign}, nil
+}
+
+// intWidth selects the smallest signed integer token that holds value.
+func intWidth(v int64) byte {
+	switch {
+	case v >= -128 && v <= 127:
+		return tokenInt8
+	case v >= -32768 && v <= 32767:
+		return tokenInt16
+	case v >= -2147483648 && v <= 2147483647:
+		return tokenInt32
+	default:
+		return tokenInt64
+	}
+}
+
+// parseOctet parses a "#hhhh..." octet-string literal.
+func parseOctet(s string) (Node, error) {
+	hexs := strings.TrimPrefix(s, "#")
+	if len(hexs)%2 != 0 {
+		return nil, fmt.Errorf("octet string %q has an odd number of hex digits", s)
+	}
+	out := make([]byte, 0, len(hexs)/2)
+	for i := 0; i < len(hexs); i += 2 {
+		b, err := strconv.ParseUint(hexs[i:i+2], 16, 8)
+		if err != nil {
+			return nil, fmt.Errorf("invalid octet string %q: %w", s, err)
+		}
+		out = append(out, byte(b))
+	}
+	return &OctetLiteral{Value: out}, nil
+}

--- a/ace/condition/serialize.go
+++ b/ace/condition/serialize.go
@@ -1,0 +1,135 @@
+package condition
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+// Precedence levels for parenthesization when serializing logical operators.
+const (
+	precOr   = 1 // ||
+	precAnd  = 2 // &&
+	precAtom = 3 // relational terms, unary ops, literals, attributes
+)
+
+func nodePrecedence(n Node) int {
+	if b, ok := n.(*BinaryOp); ok {
+		switch b.Op {
+		case tokenOr:
+			return precOr
+		case tokenAnd:
+			return precAnd
+		}
+	}
+	return precAtom
+}
+
+// serializeNode renders a node as SDDL text. parentPrec is the precedence of
+// the enclosing logical operator (0 at the top level); a child logical
+// expression of strictly lower precedence is wrapped in parentheses.
+func serializeNode(n Node, parentPrec int) string {
+	switch v := n.(type) {
+	case *Attribute:
+		return attributeText(v)
+
+	case *IntLiteral:
+		return intText(v)
+
+	case *StringLiteral:
+		return "\"" + v.Value + "\""
+
+	case *OctetLiteral:
+		var sb strings.Builder
+		sb.WriteByte('#')
+		for _, b := range v.Value {
+			fmt.Fprintf(&sb, "%02x", b)
+		}
+		return sb.String()
+
+	case *SIDLiteral:
+		return "SID(" + v.SID + ")"
+
+	case *Composite:
+		parts := make([]string, len(v.Items))
+		for i, it := range v.Items {
+			parts[i] = serializeNode(it, 0)
+		}
+		return "{" + strings.Join(parts, ", ") + "}"
+
+	case *UnaryOp:
+		return serializeUnary(v)
+
+	case *BinaryOp:
+		return serializeBinary(v, parentPrec)
+	}
+	return ""
+}
+
+func serializeUnary(v *UnaryOp) string {
+	switch v.Op {
+	case tokenNot:
+		// Wrap the operand so precedence is unambiguous on re-parse.
+		return "!(" + serializeNode(v.Operand, 0) + ")"
+	case tokenExists, tokenNotExists:
+		return operatorNames[v.Op] + " " + serializeNode(v.Operand, 0)
+	default:
+		// Member_of family: `Member_of {SID(...), ...}`.
+		return operatorNames[v.Op] + " " + serializeNode(v.Operand, 0)
+	}
+}
+
+func serializeBinary(v *BinaryOp, parentPrec int) string {
+	if v.Op == tokenAnd || v.Op == tokenOr {
+		p := nodePrecedence(v)
+		left := serializeNode(v.Left, p)
+		right := serializeNode(v.Right, p)
+		if nodePrecedence(v.Left) < p {
+			left = "(" + left + ")"
+		}
+		if nodePrecedence(v.Right) < p {
+			right = "(" + right + ")"
+		}
+		return left + " " + operatorNames[v.Op] + " " + right
+	}
+	// Relational operator: `LHS op RHS`.
+	return serializeNode(v.Left, 0) + " " + operatorNames[v.Op] + " " + serializeNode(v.Right, 0)
+}
+
+func attributeText(a *Attribute) string {
+	switch a.Token {
+	case tokenUserAttr:
+		return "@User." + a.Name
+	case tokenDeviceAttr:
+		return "@Device." + a.Name
+	case tokenResourceAttr:
+		return "@Resource." + a.Name
+	default:
+		return a.Name
+	}
+}
+
+func intText(v *IntLiteral) string {
+	var body string
+	switch v.Base {
+	case baseHex:
+		if v.Value >= 0 {
+			body = "0x" + strconv.FormatInt(v.Value, 16)
+		} else {
+			body = strconv.FormatInt(v.Value, 10)
+		}
+	case baseOctal:
+		if v.Value >= 0 {
+			body = "0" + strconv.FormatInt(v.Value, 8)
+		} else {
+			body = strconv.FormatInt(v.Value, 10)
+		}
+	default:
+		body = strconv.FormatInt(v.Value, 10)
+	}
+	// A negative value already carries its '-'; only add an explicit '+'.
+	if v.Sign == signPositive && v.Value >= 0 {
+		body = "+" + body
+	}
+	return body
+}

--- a/securitydescriptor/NtSecurityDescriptor_conditional_test.go
+++ b/securitydescriptor/NtSecurityDescriptor_conditional_test.go
@@ -1,0 +1,82 @@
+package securitydescriptor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/TheManticoreProject/winacl/ace/acetype"
+	"github.com/TheManticoreProject/winacl/ace/condition"
+)
+
+// TestConditionalACE_SDDLRoundTrip verifies that a conditional (callback) ACE's
+// conditional expression survives an SDDL parse and re-serialize, and a full
+// binary Marshal/Unmarshal round-trip. Previously the conditional-expression
+// field was dropped on both parse and serialize.
+func TestConditionalACE_SDDLRoundTrip(t *testing.T) {
+	const sddl = `D:(XA;;GA;;;S-1-1-0;(@User.Title=="PM" && (@User.Division=="Finance" || @User.Division=="Sales")))`
+
+	ntsd := &NtSecurityDescriptor{}
+	if _, err := ntsd.FromSDDLString(sddl); err != nil {
+		t.Fatalf("FromSDDLString error = %v", err)
+	}
+
+	if ntsd.DACL == nil || len(ntsd.DACL.Entries) != 1 {
+		t.Fatalf("expected exactly one DACL entry, got %+v", ntsd.DACL)
+	}
+	ace := ntsd.DACL.Entries[0]
+
+	if ace.Header.Type.Value != acetype.ACE_TYPE_ACCESS_ALLOWED_CALLBACK {
+		t.Fatalf("ACE type = 0x%02x, want ACCESS_ALLOWED_CALLBACK (0x09)", ace.Header.Type.Value)
+	}
+	if !condition.IsConditional(ace.ApplicationData) {
+		t.Fatalf("ACE ApplicationData is not a conditional expression: %x", ace.ApplicationData)
+	}
+
+	// The conditional expression must be preserved in the SDDL round-trip.
+	out, err := ntsd.ToSDDLString()
+	if err != nil {
+		t.Fatalf("ToSDDLString error = %v", err)
+	}
+	for _, want := range []string{`XA;`, `@User.Title == "PM"`, `@User.Division == "Finance"`, `@User.Division == "Sales"`, `||`, `&&`} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("ToSDDLString output missing %q:\n  %s", want, out)
+		}
+	}
+
+	// Re-parsing the serialized SDDL must yield the same ApplicationData bytes.
+	ntsd2 := &NtSecurityDescriptor{}
+	if _, err := ntsd2.FromSDDLString(out); err != nil {
+		t.Fatalf("re-FromSDDLString(%q) error = %v", out, err)
+	}
+	got := ntsd2.DACL.Entries[0].ApplicationData
+	if string(got) != string(ace.ApplicationData) {
+		t.Fatalf("conditional expression not stable across SDDL round-trip:\n  first:  %x\n  second: %x", ace.ApplicationData, got)
+	}
+
+	// Full binary round-trip: Marshal -> Unmarshal must preserve the condition.
+	bin, err := ntsd.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal error = %v", err)
+	}
+	parsed := &NtSecurityDescriptor{}
+	if _, err := parsed.Unmarshal(bin); err != nil {
+		t.Fatalf("Unmarshal error = %v", err)
+	}
+	if parsed.DACL == nil || len(parsed.DACL.Entries) != 1 {
+		t.Fatalf("binary round-trip lost the ACE")
+	}
+	if string(parsed.DACL.Entries[0].ApplicationData) != string(ace.ApplicationData) {
+		t.Fatalf("conditional expression not preserved across binary round-trip:\n  before: %x\n  after:  %x",
+			ace.ApplicationData, parsed.DACL.Entries[0].ApplicationData)
+	}
+}
+
+// TestConditionalACE_RejectedOnNonCallback verifies a conditional expression on
+// a non-callback ACE type is rejected rather than silently mishandled.
+func TestConditionalACE_RejectedOnNonCallback(t *testing.T) {
+	const sddl = `D:(A;;FX;;;S-1-1-0;(@User.Title=="PM"))`
+	ntsd := &NtSecurityDescriptor{}
+	if _, err := ntsd.FromSDDLString(sddl); err == nil {
+		t.Fatal("expected an error for a conditional expression on a non-callback ACE type, got nil")
+	}
+}

--- a/securitydescriptor/NtSecurityDescriptor_sddl.go
+++ b/securitydescriptor/NtSecurityDescriptor_sddl.go
@@ -8,6 +8,7 @@ import (
 	ntsd_ace "github.com/TheManticoreProject/winacl/ace"
 	"github.com/TheManticoreProject/winacl/ace/aceflags"
 	"github.com/TheManticoreProject/winacl/ace/acetype"
+	"github.com/TheManticoreProject/winacl/ace/condition"
 	"github.com/TheManticoreProject/winacl/acl"
 	"github.com/TheManticoreProject/winacl/acl/revision"
 	"github.com/TheManticoreProject/winacl/guid"
@@ -372,7 +373,40 @@ func sddlParseACE(aceStr string) (*ntsd_ace.AccessControlEntry, error) {
 		ace.Identity.Name = parsedSID.LookupName()
 	}
 
+	// Parse the optional conditional expression (7th field), present on callback
+	// ACE types (XA/XD/XU/ZA). It is compiled into the binary conditional-ACE
+	// format (MS-DTYP 2.4.4.17.1) and stored as the ACE's ApplicationData.
+	// Fields 6+ are rejoined in case the expression itself contained a ';'.
+	if len(parts) > 6 {
+		condStr := strings.TrimSpace(strings.Join(parts[6:], ";"))
+		if condStr != "" {
+			if !isConditionalACEType(ace.Header.Type.Value) {
+				return nil, fmt.Errorf("conditional expression present on non-callback ACE type '%s'", aceTypeStr)
+			}
+			appData, err := condition.Marshal(condStr)
+			if err != nil {
+				return nil, fmt.Errorf("failed to parse conditional expression '%s': %w", condStr, err)
+			}
+			ace.ApplicationData = appData
+		}
+	}
+
 	return ace, nil
+}
+
+// isConditionalACEType reports whether an ACE type is a callback type that can
+// carry a conditional expression in its ApplicationData.
+func isConditionalACEType(typeVal uint8) bool {
+	switch typeVal {
+	case acetype.ACE_TYPE_ACCESS_ALLOWED_CALLBACK,
+		acetype.ACE_TYPE_ACCESS_DENIED_CALLBACK,
+		acetype.ACE_TYPE_ACCESS_ALLOWED_CALLBACK_OBJECT,
+		acetype.ACE_TYPE_ACCESS_DENIED_CALLBACK_OBJECT,
+		acetype.ACE_TYPE_SYSTEM_AUDIT_CALLBACK,
+		acetype.ACE_TYPE_SYSTEM_AUDIT_CALLBACK_OBJECT:
+		return true
+	}
+	return false
 }
 
 // sddlParseACEFlags parses an SDDL ACE flags string into a combined uint8 value.
@@ -460,7 +494,21 @@ func sddlACEToString(ace *ntsd_ace.AccessControlEntry) (string, error) {
 		parts[5] = sddlSIDToString(&ace.Identity.SID)
 	}
 
-	return strings.Join(parts[:], ";"), nil
+	fields := parts[:]
+
+	// Conditional expression (7th field). If the ACE carries a conditional
+	// expression in its ApplicationData (callback ACE types), decode it back to
+	// SDDL text wrapped in parentheses, so it survives the round-trip instead of
+	// being dropped.
+	if condition.IsConditional(ace.ApplicationData) {
+		exprText, err := condition.Unmarshal(ace.ApplicationData)
+		if err != nil {
+			return "", fmt.Errorf("failed to serialize conditional expression: %w", err)
+		}
+		fields = append(fields, "("+exprText+")")
+	}
+
+	return strings.Join(fields, ";"), nil
 }
 
 // sddlACETypeToString converts an ACE type value to its SDDL abbreviation.


### PR DESCRIPTION
### Linked Issue
`Closes #106`

### Root Cause
The SDDL ACE codec in `NtSecurityDescriptor_sddl.go` modeled an ACE as exactly six semicolon-separated fields. `sddlParseACE` never read the 7th field (the conditional expression) and `sddlACEToString` never emitted it, so the conditional expression of a callback ACE (`XA`/`XD`/`XU`/`ZA`) was silently dropped on parse and serialize, even though the binary layer preserves it in `ApplicationData`. Per MS-DTYP 2.4.4.17 that expression is the criterion evaluated during an access check, so dropping it changes the meaning of the descriptor.

### Fix Description
Adds a conditional-expression codec and wires it into the SDDL layer.

- **New package `ace/condition`** implements the conditional-ACE binary format (MS-DTYP 2.4.4.17.1): the `artx` signature (`0x61 0x72 0x74 0x78`), all literal tokens (int8/16/32/64 with sign+base, Unicode string, octet string, SID, composite), the attribute-name tokens (local `0xf8`, `@User.` `0xf9`, `@Resource.` `0xfa`, `@Device.` `0xfb`), and every relational and logical operator, with LSB-first integers and DWORD (`0x00`) padding.
  - `Marshal(text) -> []byte` lexes and parses the SDDL expression (recursive-descent, `||` < `&&` < unary/relational/atom precedence) into an AST and emits the postfix token stream.
  - `Unmarshal([]byte) -> text` decodes the postfix stream via a stack machine back into SDDL text.
- **`sddlParseACE`** now compiles the 7th field into the callback ACE's `ApplicationData`; a conditional expression on a non-callback ACE type is rejected rather than silently mishandled.
- **`sddlACEToString`** decodes `ApplicationData` (when it carries the `artx` signature) back into a `;(expr)` field.

The `XA`/`XD`/`XU`/`ZA` -> ACE-type mapping was already correct and is unchanged.

### How Verified
- **Known-answer:** the encoder reproduces the exact byte sequence from MS-DTYP 2.4.4.17.2 Example 1 for `(Title=="VP")` (`61 72 74 78 f8 0a … 80 00 00 00`), and the decoder reproduces the text.
- **Round-trip:** `Marshal -> Unmarshal -> Marshal` is byte-stable across expressions covering every operator/literal/attribute form (`&&`, `||`, `!`, `==`/`!=`/`<`/`<=`/`>`/`>=`, `Contains`, `Any_of`, `Member_of` family, `Exists`, composites, SID/octet/hex/negative literals, `@User.`/`@Device.`/`@Resource.`).
- **End-to-end:** the user-reported example `D:(XA;;GA;;;S-1-1-0;(@User.Title=="PM" && (@User.Division=="Finance" || @User.Division=="Sales")))` parses to a callback ACE with an `artx` conditional expression, re-serializes with the expression intact, re-parses to identical `ApplicationData`, and survives a binary `Marshal`/`Unmarshal`.
- `go test ./...` passes.

### Test Coverage
- **Added:** `ace/condition/condition_test.go` (known-answer encode/decode, binary round-trip matrix, parse-error cases, signature detection) and `securitydescriptor/NtSecurityDescriptor_conditional_test.go` (SDDL + binary round-trip of a conditional ACE, and rejection of a conditional expression on a non-callback ACE type).

### Scope of Change
- **Files changed:** new `ace/condition/` package (`condition.go`, `parser.go`, `encode.go`, `decode.go`, `serialize.go`, `condition_test.go`); `securitydescriptor/NtSecurityDescriptor_sddl.go`; `securitydescriptor/NtSecurityDescriptor_conditional_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none. Non-callback ACEs and ACEs without a conditional expression serialize exactly as before (six fields).

### Risk and Rollout
The change is additive: ACEs that do not carry a conditional expression are unaffected. Callback ACEs now preserve their expression instead of dropping it. Safe to merge.

### Notes
Resource-attribute ACEs (`RA`, MS-DTYP 2.4.4.15) use a different trailing-field format (`attribute-data`, e.g. `TS`/`TI`/`TX`) and remain out of scope here; their round-trip could be added separately. The pre-existing decomposition of object-specific rights aliases such as `FX` in `sddlRightsToString` (which does not round-trip) is likewise unrelated and untouched.