### PR TITLE
Support resource-attribute (RA) ACEs in SDDL conversion (Fixes #110)

### DIFF
--- a/ace/resourceattribute/resourceattribute.go
+++ b/ace/resourceattribute/resourceattribute.go
@@ -1,0 +1,521 @@
+// Package resourceattribute implements the codec for the resource-attribute
+// data carried in a SYSTEM_RESOURCE_ATTRIBUTE_ACE (MS-DTYP 2.4.4.15). The ACE's
+// ApplicationData is a CLAIM_SECURITY_ATTRIBUTE_RELATIVE_V1 structure (MS-DTYP
+// 2.4.10.1); this package converts between that binary form and the SDDL
+// attribute-data text `"name",TYPE,flags,value,...` (MS-DTYP 2.5.1.1).
+//
+//	text  -> Marshal   -> CLAIM_SECURITY_ATTRIBUTE_RELATIVE_V1 bytes
+//	bytes -> Unmarshal -> text
+//
+// The structure is offset-based: a fixed 16-byte header (Name, ValueType,
+// Reserved, Flags, ValueCount) is followed by an array of ValueCount DWORD
+// offsets, each pointing (from the start of the structure) to a value; the
+// attribute name and the values themselves follow. All integers are
+// little-endian and the whole structure is padded to a DWORD boundary.
+package resourceattribute
+
+import (
+	"encoding/binary"
+	"fmt"
+	"strconv"
+	"strings"
+	"unicode/utf16"
+
+	sddl_sid "github.com/TheManticoreProject/winacl/sddl/sid"
+	"github.com/TheManticoreProject/winacl/sid"
+)
+
+// CLAIM_SECURITY_ATTRIBUTE_TYPE value-type codes (MS-DTYP 2.4.10.1).
+const (
+	TypeInt64       uint16 = 0x0001
+	TypeUint64      uint16 = 0x0002
+	TypeString      uint16 = 0x0003
+	TypeSID         uint16 = 0x0005
+	TypeBoolean     uint16 = 0x0006
+	TypeOctetString uint16 = 0x0010
+)
+
+// sddlTypeToValueType maps the SDDL resource-attribute data-type code to the
+// CLAIM_SECURITY_ATTRIBUTE_TYPE value.
+var sddlTypeToValueType = map[string]uint16{
+	"TI": TypeInt64,
+	"TU": TypeUint64,
+	"TS": TypeString,
+	"TD": TypeSID,
+	"TX": TypeOctetString,
+	"TB": TypeBoolean,
+}
+
+var valueTypeToSDDLType = map[uint16]string{
+	TypeInt64:       "TI",
+	TypeUint64:      "TU",
+	TypeString:      "TS",
+	TypeSID:         "TD",
+	TypeOctetString: "TX",
+	TypeBoolean:     "TB",
+}
+
+// ResourceAttribute is the decoded representation of a resource attribute.
+// Exactly one of the value slices is populated, chosen by ValueType.
+type ResourceAttribute struct {
+	Name      string
+	ValueType uint16
+	Flags     uint32
+
+	Ints    []int64  // TypeInt64, TypeUint64, TypeBoolean
+	Strings []string // TypeString
+	SIDs    []string // TypeSID (string form)
+	Octets  [][]byte // TypeOctetString
+}
+
+const headerLen = 16 // Name(4) + ValueType(2) + Reserved(2) + Flags(4) + ValueCount(4)
+
+// Marshal parses an SDDL attribute-data string (optionally wrapped in a single
+// outer pair of parentheses, as it appears in an ACE) and returns the binary
+// CLAIM_SECURITY_ATTRIBUTE_RELATIVE_V1 encoding.
+func Marshal(attrData string) ([]byte, error) {
+	ra, err := Parse(attrData)
+	if err != nil {
+		return nil, err
+	}
+	return ra.Encode()
+}
+
+// Unmarshal decodes CLAIM_SECURITY_ATTRIBUTE_RELATIVE_V1 bytes into the SDDL
+// attribute-data text (without an outer pair of parentheses).
+func Unmarshal(data []byte) (string, error) {
+	ra, err := Decode(data)
+	if err != nil {
+		return "", err
+	}
+	return ra.String(), nil
+}
+
+// Parse converts SDDL attribute-data text into a ResourceAttribute.
+func Parse(attrData string) (*ResourceAttribute, error) {
+	s := strings.TrimSpace(attrData)
+	// Strip a single enclosing pair of parentheses if present.
+	if strings.HasPrefix(s, "(") && strings.HasSuffix(s, ")") {
+		s = s[1 : len(s)-1]
+	}
+
+	fields := splitTopLevelCommas(s)
+	if len(fields) < 3 {
+		return nil, fmt.Errorf("resource attribute requires at least name, type and flags fields, got %q", attrData)
+	}
+
+	name, err := parseQuoted(strings.TrimSpace(fields[0]))
+	if err != nil {
+		return nil, fmt.Errorf("invalid resource attribute name: %w", err)
+	}
+
+	typeStr := strings.TrimSpace(fields[1])
+	vt, ok := sddlTypeToValueType[typeStr]
+	if !ok {
+		return nil, fmt.Errorf("unknown resource attribute type %q", typeStr)
+	}
+
+	flags, err := parseUintAuto(strings.TrimSpace(fields[2]))
+	if err != nil {
+		return nil, fmt.Errorf("invalid resource attribute flags %q: %w", fields[2], err)
+	}
+
+	ra := &ResourceAttribute{Name: name, ValueType: vt, Flags: uint32(flags)}
+
+	for _, raw := range fields[3:] {
+		v := strings.TrimSpace(raw)
+		if v == "" {
+			continue
+		}
+		if err := ra.appendValue(v); err != nil {
+			return nil, err
+		}
+	}
+	return ra, nil
+}
+
+func (ra *ResourceAttribute) appendValue(v string) error {
+	switch ra.ValueType {
+	case TypeInt64:
+		n, err := parseIntAuto(v)
+		if err != nil {
+			return fmt.Errorf("invalid TI value %q: %w", v, err)
+		}
+		ra.Ints = append(ra.Ints, n)
+	case TypeUint64:
+		n, err := parseUintAuto(v)
+		if err != nil {
+			return fmt.Errorf("invalid TU value %q: %w", v, err)
+		}
+		ra.Ints = append(ra.Ints, int64(n))
+	case TypeBoolean:
+		switch v {
+		case "0":
+			ra.Ints = append(ra.Ints, 0)
+		case "1":
+			ra.Ints = append(ra.Ints, 1)
+		default:
+			return fmt.Errorf("invalid TB value %q (must be 0 or 1)", v)
+		}
+	case TypeString:
+		s, err := parseQuoted(v)
+		if err != nil {
+			return fmt.Errorf("invalid TS value %q: %w", v, err)
+		}
+		ra.Strings = append(ra.Strings, s)
+	case TypeSID:
+		ra.SIDs = append(ra.SIDs, v)
+	case TypeOctetString:
+		b, err := parseOctet(v)
+		if err != nil {
+			return fmt.Errorf("invalid TX value %q: %w", v, err)
+		}
+		ra.Octets = append(ra.Octets, b)
+	}
+	return nil
+}
+
+// Encode serializes the ResourceAttribute into binary form.
+func (ra *ResourceAttribute) Encode() ([]byte, error) {
+	// Build the value blobs first so we can lay out offsets.
+	valueBlobs, err := ra.encodeValues()
+	if err != nil {
+		return nil, err
+	}
+	count := len(valueBlobs)
+
+	nameBytes := encodeUTF16NUL(ra.Name)
+
+	out := make([]byte, headerLen+4*count)
+	// Layout: header, offset array, name, values.
+	cursor := headerLen + 4*count
+
+	nameOffset := cursor
+	out = append(out, nameBytes...)
+	cursor += len(nameBytes)
+
+	valueOffsets := make([]int, count)
+	for i, blob := range valueBlobs {
+		valueOffsets[i] = cursor
+		out = append(out, blob...)
+		cursor += len(blob)
+	}
+
+	// Header.
+	binary.LittleEndian.PutUint32(out[0:4], uint32(nameOffset))
+	binary.LittleEndian.PutUint16(out[4:6], ra.ValueType)
+	binary.LittleEndian.PutUint16(out[6:8], 0) // Reserved
+	binary.LittleEndian.PutUint32(out[8:12], ra.Flags)
+	binary.LittleEndian.PutUint32(out[12:16], uint32(count))
+
+	// Offset array.
+	for i, off := range valueOffsets {
+		binary.LittleEndian.PutUint32(out[headerLen+4*i:headerLen+4*i+4], uint32(off))
+	}
+
+	// Pad to a DWORD boundary.
+	for len(out)%4 != 0 {
+		out = append(out, 0x00)
+	}
+	return out, nil
+}
+
+func (ra *ResourceAttribute) encodeValues() ([][]byte, error) {
+	var blobs [][]byte
+	switch ra.ValueType {
+	case TypeInt64, TypeUint64, TypeBoolean:
+		for _, n := range ra.Ints {
+			b := make([]byte, 8)
+			binary.LittleEndian.PutUint64(b, uint64(n))
+			blobs = append(blobs, b)
+		}
+	case TypeString:
+		for _, s := range ra.Strings {
+			blobs = append(blobs, encodeUTF16NUL(s))
+		}
+	case TypeSID:
+		for _, s := range ra.SIDs {
+			sidBytes, err := encodeSID(s)
+			if err != nil {
+				return nil, err
+			}
+			blobs = append(blobs, encodeOctetRelative(sidBytes))
+		}
+	case TypeOctetString:
+		for _, o := range ra.Octets {
+			blobs = append(blobs, encodeOctetRelative(o))
+		}
+	default:
+		return nil, fmt.Errorf("unsupported resource attribute value type 0x%04x", ra.ValueType)
+	}
+	return blobs, nil
+}
+
+// Decode parses CLAIM_SECURITY_ATTRIBUTE_RELATIVE_V1 bytes.
+func Decode(data []byte) (*ResourceAttribute, error) {
+	if len(data) < headerLen {
+		return nil, fmt.Errorf("resource attribute data too short (%d bytes)", len(data))
+	}
+	nameOffset := binary.LittleEndian.Uint32(data[0:4])
+	vt := binary.LittleEndian.Uint16(data[4:6])
+	flags := binary.LittleEndian.Uint32(data[8:12])
+	count := binary.LittleEndian.Uint32(data[12:16])
+
+	if _, ok := valueTypeToSDDLType[vt]; !ok {
+		return nil, fmt.Errorf("unknown resource attribute value type 0x%04x", vt)
+	}
+	if int(count) > (len(data)-headerLen)/4 {
+		return nil, fmt.Errorf("resource attribute value count %d exceeds available data", count)
+	}
+
+	ra := &ResourceAttribute{ValueType: vt, Flags: flags}
+
+	name, err := decodeUTF16NUL(data, int(nameOffset))
+	if err != nil {
+		return nil, fmt.Errorf("invalid resource attribute name: %w", err)
+	}
+	ra.Name = name
+
+	for i := 0; i < int(count); i++ {
+		off := binary.LittleEndian.Uint32(data[headerLen+4*i : headerLen+4*i+4])
+		if err := ra.decodeValue(data, int(off)); err != nil {
+			return nil, err
+		}
+	}
+	return ra, nil
+}
+
+func (ra *ResourceAttribute) decodeValue(data []byte, off int) error {
+	switch ra.ValueType {
+	case TypeInt64, TypeUint64, TypeBoolean:
+		if off < 0 || off+8 > len(data) {
+			return fmt.Errorf("integer value offset %d out of range", off)
+		}
+		ra.Ints = append(ra.Ints, int64(binary.LittleEndian.Uint64(data[off:off+8])))
+	case TypeString:
+		s, err := decodeUTF16NUL(data, off)
+		if err != nil {
+			return err
+		}
+		ra.Strings = append(ra.Strings, s)
+	case TypeSID:
+		b, err := decodeOctetRelative(data, off)
+		if err != nil {
+			return err
+		}
+		sd := &sid.SID{}
+		if _, err := sd.Unmarshal(b); err != nil {
+			return fmt.Errorf("invalid SID resource attribute value: %w", err)
+		}
+		ra.SIDs = append(ra.SIDs, sd.ToString())
+	case TypeOctetString:
+		b, err := decodeOctetRelative(data, off)
+		if err != nil {
+			return err
+		}
+		ra.Octets = append(ra.Octets, b)
+	}
+	return nil
+}
+
+// String renders the resource attribute as SDDL attribute-data text (without an
+// outer pair of parentheses).
+func (ra *ResourceAttribute) String() string {
+	var sb strings.Builder
+	sb.WriteString("\"")
+	sb.WriteString(ra.Name)
+	sb.WriteString("\",")
+	sb.WriteString(valueTypeToSDDLType[ra.ValueType])
+	sb.WriteString(",")
+	sb.WriteString(strconv.FormatUint(uint64(ra.Flags), 10))
+
+	switch ra.ValueType {
+	case TypeInt64:
+		for _, n := range ra.Ints {
+			sb.WriteString("," + strconv.FormatInt(n, 10))
+		}
+	case TypeUint64:
+		for _, n := range ra.Ints {
+			sb.WriteString("," + strconv.FormatUint(uint64(n), 10))
+		}
+	case TypeBoolean:
+		for _, n := range ra.Ints {
+			if n == 0 {
+				sb.WriteString(",0")
+			} else {
+				sb.WriteString(",1")
+			}
+		}
+	case TypeString:
+		for _, s := range ra.Strings {
+			sb.WriteString(",\"" + s + "\"")
+		}
+	case TypeSID:
+		for _, s := range ra.SIDs {
+			sb.WriteString("," + s)
+		}
+	case TypeOctetString:
+		for _, o := range ra.Octets {
+			sb.WriteString(",#")
+			for _, b := range o {
+				fmt.Fprintf(&sb, "%02x", b)
+			}
+		}
+	}
+	return sb.String()
+}
+
+// ---------------------------------------------------------------------------
+// Encoding helpers
+// ---------------------------------------------------------------------------
+
+func encodeUTF16NUL(s string) []byte {
+	u16 := utf16.Encode([]rune(s))
+	out := make([]byte, 0, len(u16)*2+2)
+	for _, c := range u16 {
+		var b [2]byte
+		binary.LittleEndian.PutUint16(b[:], c)
+		out = append(out, b[:]...)
+	}
+	out = append(out, 0x00, 0x00) // NUL terminator
+	return out
+}
+
+func decodeUTF16NUL(data []byte, off int) (string, error) {
+	if off < 0 || off > len(data) {
+		return "", fmt.Errorf("string offset %d out of range", off)
+	}
+	var u16 []uint16
+	for i := off; i+1 < len(data); i += 2 {
+		c := binary.LittleEndian.Uint16(data[i : i+2])
+		if c == 0 {
+			return string(utf16.Decode(u16)), nil
+		}
+		u16 = append(u16, c)
+	}
+	return "", fmt.Errorf("unterminated UTF-16 string at offset %d", off)
+}
+
+// encodeOctetRelative builds a CLAIM_SECURITY_ATTRIBUTE_OCTET_STRING_RELATIVE:
+// a DWORD length followed by the bytes.
+func encodeOctetRelative(b []byte) []byte {
+	out := make([]byte, 4, 4+len(b))
+	binary.LittleEndian.PutUint32(out, uint32(len(b)))
+	return append(out, b...)
+}
+
+func decodeOctetRelative(data []byte, off int) ([]byte, error) {
+	if off < 0 || off+4 > len(data) {
+		return nil, fmt.Errorf("octet string offset %d out of range", off)
+	}
+	l := int(binary.LittleEndian.Uint32(data[off : off+4]))
+	if off+4+l > len(data) {
+		return nil, fmt.Errorf("octet string length %d at offset %d exceeds available data", l, off)
+	}
+	out := make([]byte, l)
+	copy(out, data[off+4:off+4+l])
+	return out, nil
+}
+
+func encodeSID(s string) ([]byte, error) {
+	resolved := strings.TrimSpace(s)
+	if full, ok := sddl_sid.SDDLToSID[resolved]; ok {
+		resolved = full
+	}
+	if !strings.HasPrefix(resolved, "S-") {
+		return nil, fmt.Errorf("unknown SID %q in resource attribute", s)
+	}
+	sd := &sid.SID{}
+	if err := sd.FromString(resolved); err != nil {
+		return nil, fmt.Errorf("invalid SID %q: %w", s, err)
+	}
+	return sd.Marshal()
+}
+
+// ---------------------------------------------------------------------------
+// SDDL text helpers
+// ---------------------------------------------------------------------------
+
+// splitTopLevelCommas splits on commas that are not inside a double-quoted
+// string.
+func splitTopLevelCommas(s string) []string {
+	var parts []string
+	var cur strings.Builder
+	inQuote := false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c == '"':
+			inQuote = !inQuote
+			cur.WriteByte(c)
+		case c == ',' && !inQuote:
+			parts = append(parts, cur.String())
+			cur.Reset()
+		default:
+			cur.WriteByte(c)
+		}
+	}
+	parts = append(parts, cur.String())
+	return parts
+}
+
+func parseQuoted(s string) (string, error) {
+	if len(s) < 2 || s[0] != '"' || s[len(s)-1] != '"' {
+		return "", fmt.Errorf("expected a double-quoted string, got %q", s)
+	}
+	return s[1 : len(s)-1], nil
+}
+
+func parseIntAuto(s string) (int64, error) {
+	neg := false
+	body := s
+	if strings.HasPrefix(body, "-") {
+		neg = true
+		body = body[1:]
+	} else if strings.HasPrefix(body, "+") {
+		body = body[1:]
+	}
+	var v int64
+	var err error
+	switch {
+	case strings.HasPrefix(body, "0x") || strings.HasPrefix(body, "0X"):
+		v, err = strconv.ParseInt(body[2:], 16, 64)
+	default:
+		v, err = strconv.ParseInt(body, 10, 64)
+	}
+	if err != nil {
+		return 0, err
+	}
+	if neg {
+		v = -v
+	}
+	return v, nil
+}
+
+func parseUintAuto(s string) (uint64, error) {
+	body := s
+	if strings.HasPrefix(body, "0x") || strings.HasPrefix(body, "0X") {
+		return strconv.ParseUint(body[2:], 16, 64)
+	}
+	return strconv.ParseUint(body, 10, 64)
+}
+
+func parseOctet(s string) ([]byte, error) {
+	if !strings.HasPrefix(s, "#") {
+		return nil, fmt.Errorf("octet string must start with '#'")
+	}
+	// Per MS-DTYP, '#' is synonymous with '0' padding inside octet strings.
+	hexs := strings.ReplaceAll(s[1:], "#", "0")
+	if len(hexs)%2 != 0 {
+		return nil, fmt.Errorf("octet string has an odd number of hex digits")
+	}
+	out := make([]byte, 0, len(hexs)/2)
+	for i := 0; i < len(hexs); i += 2 {
+		b, err := strconv.ParseUint(hexs[i:i+2], 16, 8)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, byte(b))
+	}
+	return out, nil
+}

--- a/ace/resourceattribute/resourceattribute_test.go
+++ b/ace/resourceattribute/resourceattribute_test.go
@@ -1,0 +1,83 @@
+package resourceattribute_test
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/winacl/ace/resourceattribute"
+)
+
+// TestRoundTrip verifies Marshal -> Unmarshal -> Marshal is byte-stable and the
+// decoded text matches expectations for each resource-attribute value type.
+func TestRoundTrip(t *testing.T) {
+	cases := []struct {
+		name string
+		text string
+	}{
+		{"string-multi", `"Project",TS,0,"Windows","SQL"`},
+		{"string-single", `"Dept",TS,0,"Finance"`},
+		{"uint", `"Secrecy",TU,0,3`},
+		{"int-negative", `"Offset",TI,0,-5`},
+		{"int-multi", `"Levels",TI,0,1,2,3`},
+		{"bool", `"Enabled",TB,0,1`},
+		{"bool-false", `"Enabled",TB,0,0`},
+		{"octet", `"Blob",TX,0,#01ff2a`},
+		{"sid", `"Owner",TD,0,S-1-1-0`},
+		{"flags-hex", `"Marked",TU,0x10,7`},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			bin1, err := resourceattribute.Marshal(tc.text)
+			if err != nil {
+				t.Fatalf("Marshal(%q) error = %v", tc.text, err)
+			}
+			if len(bin1)%4 != 0 {
+				t.Fatalf("encoding not DWORD-aligned (%d bytes)", len(bin1))
+			}
+			text, err := resourceattribute.Unmarshal(bin1)
+			if err != nil {
+				t.Fatalf("Unmarshal error = %v", err)
+			}
+			bin2, err := resourceattribute.Marshal(text)
+			if err != nil {
+				t.Fatalf("re-Marshal(%q) error = %v", text, err)
+			}
+			if string(bin1) != string(bin2) {
+				t.Fatalf("binary round-trip not stable for %q:\n  first:  %x\n  via %q\n  second: %x", tc.text, bin1, text, bin2)
+			}
+		})
+	}
+}
+
+// TestParsedFields checks the decoded structure of a known attribute.
+func TestParsedFields(t *testing.T) {
+	ra, err := resourceattribute.Parse(`("Project",TS,0,"Windows","SQL")`)
+	if err != nil {
+		t.Fatalf("Parse error = %v", err)
+	}
+	if ra.Name != "Project" {
+		t.Errorf("Name = %q, want Project", ra.Name)
+	}
+	if ra.ValueType != resourceattribute.TypeString {
+		t.Errorf("ValueType = 0x%04x, want TypeString", ra.ValueType)
+	}
+	if len(ra.Strings) != 2 || ra.Strings[0] != "Windows" || ra.Strings[1] != "SQL" {
+		t.Errorf("Strings = %v, want [Windows SQL]", ra.Strings)
+	}
+}
+
+// TestParseErrors verifies malformed attribute data is rejected.
+func TestParseErrors(t *testing.T) {
+	bad := []string{
+		`"Name"`,             // missing type and flags
+		`"Name",TZ,0,1`,      // unknown type
+		`"Name",TB,0,2`,      // invalid boolean
+		`Name,TS,0,"x"`,      // unquoted name
+		`"Name",TI,0,notint`, // invalid integer
+	}
+	for _, s := range bad {
+		if _, err := resourceattribute.Marshal(s); err == nil {
+			t.Errorf("Marshal(%q) expected an error, got nil", s)
+		}
+	}
+}

--- a/securitydescriptor/NtSecurityDescriptor_resourceattr_test.go
+++ b/securitydescriptor/NtSecurityDescriptor_resourceattr_test.go
@@ -1,0 +1,73 @@
+package securitydescriptor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/TheManticoreProject/winacl/ace/acetype"
+	"github.com/TheManticoreProject/winacl/ace/resourceattribute"
+)
+
+// TestResourceAttributeACE_SDDLRoundTrip verifies that a resource-attribute (RA)
+// ACE's attribute-data survives an SDDL parse/serialize and a full binary
+// Marshal/Unmarshal round-trip. Previously the attribute-data field was dropped.
+func TestResourceAttributeACE_SDDLRoundTrip(t *testing.T) {
+	const sddl = `S:(RA;;;;;S-1-1-0;("Project",TS,0,"Windows","SQL"))`
+
+	ntsd := &NtSecurityDescriptor{}
+	if _, err := ntsd.FromSDDLString(sddl); err != nil {
+		t.Fatalf("FromSDDLString error = %v", err)
+	}
+	if ntsd.SACL == nil || len(ntsd.SACL.Entries) != 1 {
+		t.Fatalf("expected one SACL entry, got %+v", ntsd.SACL)
+	}
+	ace := ntsd.SACL.Entries[0]
+	if ace.Header.Type.Value != acetype.ACE_TYPE_SYSTEM_RESOURCE_ATTRIBUTE {
+		t.Fatalf("ACE type = 0x%02x, want SYSTEM_RESOURCE_ATTRIBUTE (0x12)", ace.Header.Type.Value)
+	}
+	if len(ace.ApplicationData) == 0 {
+		t.Fatal("resource attribute ApplicationData is empty")
+	}
+
+	// The attribute data must decode to the expected fields.
+	ra, err := resourceattribute.Decode(ace.ApplicationData)
+	if err != nil {
+		t.Fatalf("Decode error = %v", err)
+	}
+	if ra.Name != "Project" || len(ra.Strings) != 2 {
+		t.Fatalf("decoded attribute = %+v, want name Project with 2 strings", ra)
+	}
+
+	// SDDL round-trip preserves the attribute.
+	out, err := ntsd.ToSDDLString()
+	if err != nil {
+		t.Fatalf("ToSDDLString error = %v", err)
+	}
+	for _, want := range []string{`RA;`, `"Project"`, `TS`, `"Windows"`, `"SQL"`} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("ToSDDLString output missing %q:\n  %s", want, out)
+		}
+	}
+
+	ntsd2 := &NtSecurityDescriptor{}
+	if _, err := ntsd2.FromSDDLString(out); err != nil {
+		t.Fatalf("re-FromSDDLString(%q) error = %v", out, err)
+	}
+	if string(ntsd2.SACL.Entries[0].ApplicationData) != string(ace.ApplicationData) {
+		t.Fatalf("attribute data not stable across SDDL round-trip:\n  first:  %x\n  second: %x",
+			ace.ApplicationData, ntsd2.SACL.Entries[0].ApplicationData)
+	}
+
+	// Full binary round-trip.
+	bin, err := ntsd.Marshal()
+	if err != nil {
+		t.Fatalf("Marshal error = %v", err)
+	}
+	parsed := &NtSecurityDescriptor{}
+	if _, err := parsed.Unmarshal(bin); err != nil {
+		t.Fatalf("Unmarshal error = %v", err)
+	}
+	if string(parsed.SACL.Entries[0].ApplicationData) != string(ace.ApplicationData) {
+		t.Fatalf("attribute data not preserved across binary round-trip")
+	}
+}

--- a/securitydescriptor/NtSecurityDescriptor_sddl.go
+++ b/securitydescriptor/NtSecurityDescriptor_sddl.go
@@ -9,6 +9,7 @@ import (
 	"github.com/TheManticoreProject/winacl/ace/aceflags"
 	"github.com/TheManticoreProject/winacl/ace/acetype"
 	"github.com/TheManticoreProject/winacl/ace/condition"
+	"github.com/TheManticoreProject/winacl/ace/resourceattribute"
 	"github.com/TheManticoreProject/winacl/acl"
 	"github.com/TheManticoreProject/winacl/acl/revision"
 	"github.com/TheManticoreProject/winacl/guid"
@@ -373,21 +374,31 @@ func sddlParseACE(aceStr string) (*ntsd_ace.AccessControlEntry, error) {
 		ace.Identity.Name = parsedSID.LookupName()
 	}
 
-	// Parse the optional conditional expression (7th field), present on callback
-	// ACE types (XA/XD/XU/ZA). It is compiled into the binary conditional-ACE
-	// format (MS-DTYP 2.4.4.17.1) and stored as the ACE's ApplicationData.
-	// Fields 6+ are rejoined in case the expression itself contained a ';'.
+	// Parse the optional 7th field. Callback ACE types (XA/XD/XU/ZA) carry a
+	// conditional expression compiled into the MS-DTYP 2.4.4.17.1 format;
+	// resource-attribute ACEs (RA) carry attribute-data compiled into a
+	// CLAIM_SECURITY_ATTRIBUTE_RELATIVE_V1 (MS-DTYP 2.4.10.1). Either way the
+	// result is stored as the ACE's ApplicationData. Fields 6+ are rejoined in
+	// case the value itself contained a ';'.
 	if len(parts) > 6 {
-		condStr := strings.TrimSpace(strings.Join(parts[6:], ";"))
-		if condStr != "" {
-			if !isConditionalACEType(ace.Header.Type.Value) {
-				return nil, fmt.Errorf("conditional expression present on non-callback ACE type '%s'", aceTypeStr)
+		trailer := strings.TrimSpace(strings.Join(parts[6:], ";"))
+		if trailer != "" {
+			switch {
+			case isConditionalACEType(ace.Header.Type.Value):
+				appData, err := condition.Marshal(trailer)
+				if err != nil {
+					return nil, fmt.Errorf("failed to parse conditional expression '%s': %w", trailer, err)
+				}
+				ace.ApplicationData = appData
+			case ace.Header.Type.Value == acetype.ACE_TYPE_SYSTEM_RESOURCE_ATTRIBUTE:
+				appData, err := resourceattribute.Marshal(trailer)
+				if err != nil {
+					return nil, fmt.Errorf("failed to parse resource attribute '%s': %w", trailer, err)
+				}
+				ace.ApplicationData = appData
+			default:
+				return nil, fmt.Errorf("trailing data present on ACE type '%s' that supports no 7th field", aceTypeStr)
 			}
-			appData, err := condition.Marshal(condStr)
-			if err != nil {
-				return nil, fmt.Errorf("failed to parse conditional expression '%s': %w", condStr, err)
-			}
-			ace.ApplicationData = appData
 		}
 	}
 
@@ -496,16 +507,23 @@ func sddlACEToString(ace *ntsd_ace.AccessControlEntry) (string, error) {
 
 	fields := parts[:]
 
-	// Conditional expression (7th field). If the ACE carries a conditional
-	// expression in its ApplicationData (callback ACE types), decode it back to
-	// SDDL text wrapped in parentheses, so it survives the round-trip instead of
+	// 7th field. A callback ACE carrying a conditional expression, or a
+	// resource-attribute ACE carrying CLAIM attribute-data, is decoded back to
+	// SDDL text wrapped in parentheses so it survives the round-trip instead of
 	// being dropped.
-	if condition.IsConditional(ace.ApplicationData) {
+	switch {
+	case condition.IsConditional(ace.ApplicationData):
 		exprText, err := condition.Unmarshal(ace.ApplicationData)
 		if err != nil {
 			return "", fmt.Errorf("failed to serialize conditional expression: %w", err)
 		}
 		fields = append(fields, "("+exprText+")")
+	case ace.Header.Type.Value == acetype.ACE_TYPE_SYSTEM_RESOURCE_ATTRIBUTE && len(ace.ApplicationData) > 0:
+		attrText, err := resourceattribute.Unmarshal(ace.ApplicationData)
+		if err != nil {
+			return "", fmt.Errorf("failed to serialize resource attribute: %w", err)
+		}
+		fields = append(fields, "("+attrText+")")
 	}
 
 	return strings.Join(fields, ";"), nil


### PR DESCRIPTION
### Linked Issue
`Closes #110`

### Root Cause
The SDDL ACE codec had no support for the resource-attribute (7th) field of an `RA` ACE, so it was dropped on parse and never emitted on serialize — even though the binary layer preserves the ACE's `ApplicationData`. An `RA` ACE's `ApplicationData` is a `CLAIM_SECURITY_ATTRIBUTE_RELATIVE_V1` structure (MS-DTYP 2.4.10.1) whose SDDL form is `"name",TYPE,flags,value,...`.

### Fix Description
Adds a resource-attribute codec and wires it into the SDDL layer.

- **New package `ace/resourceattribute`** implements `CLAIM_SECURITY_ATTRIBUTE_RELATIVE_V1` (offset-based: a 16-byte header — Name/ValueType/Reserved/Flags/ValueCount — followed by a ValueCount-entry DWORD offset array and the pointed-to name and values), including the nested `CLAIM_SECURITY_ATTRIBUTE_OCTET_STRING_RELATIVE` (`{DWORD Length; bytes}`) used by SID and octet-string values. All integers are little-endian; strings and the name are NUL-terminated UTF-16; the structure is DWORD-padded.
  - Value types: `TI`→INT64 (0x1), `TU`→UINT64 (0x2), `TS`→STRING (0x3), `TD`→SID (0x5), `TX`→OCTET_STRING (0x10), `TB`→BOOLEAN (0x6).
  - `Marshal(text) -> []byte` parses the quote-aware, comma-separated attribute-data; `Unmarshal([]byte) -> text` decodes it back, following the internal offsets.
- **`sddlParseACE`** compiles the 7th field into `ApplicationData` for RA ACEs (and still for callback conditional ACEs); a 7th field on any other ACE type is rejected.
- **`sddlACEToString`** decodes an RA ACE's `ApplicationData` back into a `;("name",TYPE,flags,values)` field.

### How Verified
- **Round-trip:** `Marshal -> Unmarshal -> Marshal` is byte-stable across every value type (TI incl. negative, TU, TS multi-value, TD SID, TX octet, TB, hex flags).
- **End-to-end:** `S:(RA;;;;;S-1-1-0;("Project",TS,0,"Windows","SQL"))` parses to an RA ACE with a decoded CLAIM structure, re-serializes with the attribute intact, re-parses to identical `ApplicationData`, and survives a binary `Marshal`/`Unmarshal`.
- `go test ./...` passes.

### Test Coverage
- **Added:** `ace/resourceattribute/resourceattribute_test.go` (per-type binary round-trip matrix, field decoding, parse-error cases) and `securitydescriptor/NtSecurityDescriptor_resourceattr_test.go` (SDDL + binary round-trip of an RA ACE).

### Scope of Change
- **Files changed:** new `ace/resourceattribute/` package (`resourceattribute.go`, `resourceattribute_test.go`); `securitydescriptor/NtSecurityDescriptor_sddl.go`; `securitydescriptor/NtSecurityDescriptor_resourceattr_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none. Non-RA ACEs and RA ACEs without attribute-data are unaffected.

### Risk and Rollout
Additive: RA ACEs now preserve their attribute-data instead of dropping it; all other ACEs are unchanged. Safe to merge.