### PR TITLE
[bug] Make SDDL splitter paren/quote-aware and preserve present-but-empty DACL/SACL (Fixes #112)

### DIFF
--- a/securitydescriptor/NtSecurityDescriptor_cutsddl_test.go
+++ b/securitydescriptor/NtSecurityDescriptor_cutsddl_test.go
@@ -1,0 +1,94 @@
+package securitydescriptor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/TheManticoreProject/winacl/securitydescriptor/control"
+)
+
+// TestCutSDDL_ColonInLiteral is a regression test for cutSDDL misattributing an
+// O:/G:/D:/S: substring that occurs inside a conditional-expression or
+// resource-attribute quoted literal (e.g. a Windows path "D:\\..." or a value
+// like "S:ecret") as a top-level section marker, which corrupted parsing.
+func TestCutSDDL_ColonInLiteral(t *testing.T) {
+	cases := []string{
+		`D:(XA;;FR;;;WD;(@User.Title=="S:enior"))`,
+		`D:(RA;;;;;WD;("x",TS,0,"S:ecret"))`,
+		`D:(RA;;;;;WD;("path",TS,0,"D:\Windows"))`,
+		`D:(XA;;FR;;;WD;(@User.Path=="G:foo" || @User.Path=="O:bar"))`,
+	}
+	for _, sddl := range cases {
+		t.Run(sddl, func(t *testing.T) {
+			ntsd := &NtSecurityDescriptor{}
+			if _, err := ntsd.FromSDDLString(sddl); err != nil {
+				t.Fatalf("FromSDDLString(%q) error = %v", sddl, err)
+			}
+			if ntsd.DACL == nil || len(ntsd.DACL.Entries) != 1 {
+				t.Fatalf("expected one DACL entry, got %+v", ntsd.DACL)
+			}
+			if len(ntsd.DACL.Entries[0].ApplicationData) == 0 {
+				t.Fatal("ACE ApplicationData is empty; the 7th field was lost")
+			}
+		})
+	}
+}
+
+// TestCutSDDL_ParenInQuotedLiteral verifies that parentheses inside a quoted
+// literal are treated as data, not ACE delimiters.
+func TestCutSDDL_ParenInQuotedLiteral(t *testing.T) {
+	const sddl = `D:(XA;;FR;;;WD;(@User.Note=="a)b(c"))`
+	ntsd := &NtSecurityDescriptor{}
+	if _, err := ntsd.FromSDDLString(sddl); err != nil {
+		t.Fatalf("FromSDDLString error = %v", err)
+	}
+	if ntsd.DACL == nil || len(ntsd.DACL.Entries) != 1 {
+		t.Fatalf("expected one DACL entry, got %+v", ntsd.DACL)
+	}
+}
+
+// TestFromSDDLString_PresentEmptyDACL is a regression test for a present-but-
+// empty DACL/SACL being dropped: "D:"/"S:" with no ACEs must create an empty
+// (present) ACL and set SE_DACL_PRESENT/SE_SACL_PRESENT, round-tripping back.
+func TestFromSDDLString_PresentEmptyDACL(t *testing.T) {
+	const sddl = `O:SYG:SYD:S:`
+	ntsd := &NtSecurityDescriptor{}
+	if _, err := ntsd.FromSDDLString(sddl); err != nil {
+		t.Fatalf("FromSDDLString error = %v", err)
+	}
+	if ntsd.DACL == nil {
+		t.Fatal("present-but-empty DACL was dropped (DACL is nil)")
+	}
+	if ntsd.SACL == nil {
+		t.Fatal("present-but-empty SACL was dropped (SACL is nil)")
+	}
+	if !ntsd.Header.Control.HasControl(control.NT_SECURITY_DESCRIPTOR_CONTROL_DP) {
+		t.Error("SE_DACL_PRESENT not set for a present empty DACL")
+	}
+	if !ntsd.Header.Control.HasControl(control.NT_SECURITY_DESCRIPTOR_CONTROL_SP) {
+		t.Error("SE_SACL_PRESENT not set for a present empty SACL")
+	}
+
+	out, err := ntsd.ToSDDLString()
+	if err != nil {
+		t.Fatalf("ToSDDLString error = %v", err)
+	}
+	if !strings.Contains(out, "D:") || !strings.Contains(out, "S:") {
+		t.Fatalf("present empty DACL/SACL lost on re-serialization: %q", out)
+	}
+}
+
+// TestFromSDDLString_AbsentDACL verifies an absent D: stays absent (NULL DACL).
+func TestFromSDDLString_AbsentDACL(t *testing.T) {
+	const sddl = `O:SYG:SY`
+	ntsd := &NtSecurityDescriptor{}
+	if _, err := ntsd.FromSDDLString(sddl); err != nil {
+		t.Fatalf("FromSDDLString error = %v", err)
+	}
+	if ntsd.DACL != nil {
+		t.Error("absent DACL should remain nil (NULL DACL)")
+	}
+	if ntsd.Header.Control.HasControl(control.NT_SECURITY_DESCRIPTOR_CONTROL_DP) {
+		t.Error("SE_DACL_PRESENT must not be set when no D: token is present")
+	}
+}

--- a/securitydescriptor/NtSecurityDescriptor_sddl.go
+++ b/securitydescriptor/NtSecurityDescriptor_sddl.go
@@ -33,7 +33,7 @@ import (
 // Returns:
 //   - (int, error): Always returns 0 for the int value, and an error if parsing fails.
 func (ntsd *NtSecurityDescriptor) FromSDDLString(sddlString string) (int, error) {
-	ownerStr, groupStr, daclFlags, daclAces, saclFlags, saclAces, err := cutSDDL(sddlString)
+	ownerStr, groupStr, daclPresent, daclFlags, daclAces, saclPresent, saclFlags, saclAces, err := cutSDDL(sddlString)
 	if err != nil {
 		return 0, fmt.Errorf("failed to parse SDDL: %w", err)
 	}
@@ -60,8 +60,10 @@ func (ntsd *NtSecurityDescriptor) FromSDDLString(sddlString string) (int, error)
 		ntsd.Group.Name = groupSID.LookupName()
 	}
 
-	// Parse DACL
-	if len(daclAces) > 0 || daclFlags != "" {
+	// Parse DACL. A "D:" token, even with no ACEs and no flags, means the DACL
+	// is present (SE_DACL_PRESENT) — an empty DACL that denies all access, which
+	// is distinct from an absent (NULL) DACL that grants all access.
+	if daclPresent {
 		var entries []ntsd_ace.AccessControlEntry
 		if len(daclAces) > 0 {
 			var err error
@@ -88,8 +90,9 @@ func (ntsd *NtSecurityDescriptor) FromSDDLString(sddlString string) (int, error)
 		}
 	}
 
-	// Parse SACL
-	if len(saclAces) > 0 || saclFlags != "" {
+	// Parse SACL. As with the DACL, an "S:" token marks the SACL present even
+	// when it carries no ACEs.
+	if saclPresent {
 		var entries []ntsd_ace.AccessControlEntry
 		if len(saclAces) > 0 {
 			var err error
@@ -176,11 +179,13 @@ func (ntsd *NtSecurityDescriptor) ToSDDLString() (string, error) {
 
 // cutSDDL parses an SDDL string into its component parts.
 // This is a local copy to avoid circular imports with the sddl package.
-// Returns: owner, group, daclFlags, daclAces, saclFlags, saclAces, error
-func cutSDDL(sddlString string) (string, string, string, []string, string, []string, error) {
+// Returns: owner, group, daclPresent, daclFlags, daclAces, saclPresent, saclFlags, saclAces, error.
+// daclPresent/saclPresent report whether a D:/S: token appeared at all, so a
+// present-but-empty ACL ("D:" with no ACEs) is distinguished from an absent one.
+func cutSDDL(sddlString string) (string, string, bool, string, []string, bool, string, []string, error) {
 	sddlString = strings.TrimSpace(sddlString)
 	if len(sddlString) == 0 {
-		return "", "", "", nil, "", nil, nil
+		return "", "", false, "", nil, false, "", nil, nil
 	}
 
 	components := map[string]string{
@@ -189,32 +194,59 @@ func cutSDDL(sddlString string) (string, string, string, []string, string, []str
 		"D:": "",
 		"S:": "",
 	}
+	present := map[string]bool{}
 
 	currentComponent := ""
+	depth := 0
+	inQuote := false
 	k := 0
 	for k < len(sddlString) {
-		upperChar := strings.ToUpper(string(sddlString[k]))
-		if k+1 < len(sddlString) && (upperChar == "O" || upperChar == "G" || upperChar == "D" || upperChar == "S") && sddlString[k+1] == ':' {
-			currentComponent = upperChar + ":"
-			k += 2
-			continue
+		c := sddlString[k]
+
+		// Recognize an O:/G:/D:/S: section marker only at the top level, i.e.
+		// outside any ACE parentheses and outside a quoted string literal. A
+		// conditional expression or resource-attribute value inside an ACE may
+		// legally contain a substring like "D:" (e.g. a Windows path or an
+		// arbitrary string attribute), which must not start a new component.
+		if depth == 0 && !inQuote && k+1 < len(sddlString) && sddlString[k+1] == ':' {
+			upperChar := strings.ToUpper(string(c))
+			if upperChar == "O" || upperChar == "G" || upperChar == "D" || upperChar == "S" {
+				currentComponent = upperChar + ":"
+				present[currentComponent] = true
+				k += 2
+				continue
+			}
 		}
+
+		// Track quote and (outside quotes) parenthesis nesting so markers are
+		// only detected between top-level components.
+		switch {
+		case c == '"':
+			inQuote = !inQuote
+		case !inQuote && c == '(':
+			depth++
+		case !inQuote && c == ')':
+			if depth > 0 {
+				depth--
+			}
+		}
+
 		if currentComponent != "" {
-			components[currentComponent] += string(sddlString[k])
+			components[currentComponent] += string(c)
 		}
 		k++
 	}
 
 	daclFlags, daclAces, err := cutAces(components["D:"])
 	if err != nil {
-		return "", "", "", nil, "", nil, fmt.Errorf("DACL: %w", err)
+		return "", "", false, "", nil, false, "", nil, fmt.Errorf("DACL: %w", err)
 	}
 	saclFlags, saclAces, err := cutAces(components["S:"])
 	if err != nil {
-		return "", "", "", nil, "", nil, fmt.Errorf("SACL: %w", err)
+		return "", "", false, "", nil, false, "", nil, fmt.Errorf("SACL: %w", err)
 	}
 
-	return components["O:"], components["G:"], daclFlags, daclAces, saclFlags, saclAces, nil
+	return components["O:"], components["G:"], present["D:"], daclFlags, daclAces, present["S:"], saclFlags, saclAces, nil
 }
 
 // cutAces extracts the ACL flags prefix and individual ACE strings from a DACL/SACL component.
@@ -231,9 +263,20 @@ func cutAces(aclStr string) (string, []string, error) {
 	aclFlags := strings.TrimSpace(aclStr[:start])
 
 	depth := 0
+	inQuote := false
 	aceStart := start
 	for i := start; i < len(aclStr); i++ {
-		switch aclStr[i] {
+		c := aclStr[i]
+		// Parentheses inside a quoted string literal (in a conditional
+		// expression or resource-attribute value) are data, not ACE delimiters.
+		if c == '"' {
+			inQuote = !inQuote
+			continue
+		}
+		if inQuote {
+			continue
+		}
+		switch c {
 		case '(':
 			if depth == 0 {
 				aceStart = i + 1


### PR DESCRIPTION
### Linked Issue
`Closes #112`

### Root Cause
`cutSDDL` split the SDDL string into O:/G:/D:/S: components by scanning for any `X:` substring, with no awareness of ACE parenthesis nesting or quoted string literals. Once conditional (XA/XD/XU/ZA) and resource-attribute (RA) ACEs gained 7th-field support, those fields can contain quoted literals with `:` (Windows paths, string attribute values), which were misread as section markers — mis-routing the rest of the DACL and yielding a spurious `unclosed '('`. `cutAces` likewise counted parentheses without quote awareness. Separately, an absent `D:` and a present-but-empty `D:` both collapsed to an empty component string, and `FromSDDLString` created a DACL only when it had ACEs or flags — so a present empty DACL (deny-all) was dropped and became a NULL DACL (allow-all).

### Fix Description
- `cutSDDL` now tracks parenthesis depth and quoted-string state, and recognizes an `O:`/`G:`/`D:`/`S:` marker only at the top level (depth 0, outside quotes). It also records whether each `D:`/`S:` token appeared and returns `daclPresent`/`saclPresent`.
- `cutAces` now treats `"` as toggling a quoted literal and ignores parentheses inside it, so `(`/`)` in a conditional/RA value are data, not ACE delimiters.
- `FromSDDLString` gates DACL/SACL creation on `daclPresent`/`saclPresent`, so a present-but-empty `D:`/`S:` creates an empty (present) ACL and sets `SE_DACL_PRESENT`/`SE_SACL_PRESENT`; an absent token stays a NULL ACL.

### How Verified
- **Runtime:** `D:(RA;;;;;WD;("x",TS,0,"S:ecret"))`, `D:(XA;;FR;;;WD;(@User.Title=="S:enior"))`, `("path",TS,0,"D:\Windows")` and a quoted `"a)b(c"` all now parse with the ACE and its 7th field intact; `O:SYG:SYD:S:` round-trips with both empty ACLs present (DP/SP set), while `O:SYG:SY` keeps the DACL absent.
- **Tests:** `go test ./...` passes, including the existing SDDL and involution suites.

### Test Coverage
- **Added:** `securitydescriptor/NtSecurityDescriptor_cutsddl_test.go` — `TestCutSDDL_ColonInLiteral`, `TestCutSDDL_ParenInQuotedLiteral`, `TestFromSDDLString_PresentEmptyDACL`, `TestFromSDDLString_AbsentDACL`.

### Scope of Change
- **Files changed:** `securitydescriptor/NtSecurityDescriptor_sddl.go`, `securitydescriptor/NtSecurityDescriptor_cutsddl_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none. `cutSDDL`'s return signature gained `daclPresent`/`saclPresent` (internal, unexported); ordinary SDDL strings split identically.

### Risk and Rollout
Local to the SDDL splitter and DACL/SACL gating. Ordinary descriptors are unaffected; previously-rejected valid conditional/RA strings now parse, and present-empty ACLs are preserved. Safe to merge.