### PR TITLE
[bug] Make NtSecurityDescriptorControl.Equal order-independent (Fixes #114)

### DIFF
--- a/securitydescriptor/control/NtSecurityDescriptorControl_equal_test.go
+++ b/securitydescriptor/control/NtSecurityDescriptorControl_equal_test.go
@@ -1,0 +1,47 @@
+package control_test
+
+import (
+	"testing"
+
+	"github.com/TheManticoreProject/winacl/securitydescriptor/control"
+)
+
+// TestControl_Equal_Deterministic is a regression test for Equal comparing the
+// Values/Flags slices positionally. Those slices are filled from randomized Go
+// map iteration, so two controls decoded from identical bytes compared unequal
+// a large fraction of the time. Equality must depend only on RawValue.
+func TestControl_Equal_Deterministic(t *testing.T) {
+	// 0x8004 = SE_SELF_RELATIVE | SE_DACL_PRESENT (two bits, so slice order can differ).
+	raw := []byte{0x04, 0x80}
+
+	var reference control.NtSecurityDescriptorControl
+	if _, err := reference.Unmarshal(raw); err != nil {
+		t.Fatalf("Unmarshal error = %v", err)
+	}
+
+	for i := 0; i < 1000; i++ {
+		var other control.NtSecurityDescriptorControl
+		if _, err := other.Unmarshal(raw); err != nil {
+			t.Fatalf("Unmarshal error = %v", err)
+		}
+		if !reference.Equal(&other) {
+			t.Fatalf("iteration %d: controls decoded from identical bytes compared unequal (Values %v vs %v)",
+				i, reference.Values, other.Values)
+		}
+	}
+}
+
+// TestControl_Equal_DifferentValues verifies Equal still distinguishes different
+// control words.
+func TestControl_Equal_DifferentValues(t *testing.T) {
+	var a, b control.NtSecurityDescriptorControl
+	if _, err := a.Unmarshal([]byte{0x04, 0x80}); err != nil { // 0x8004
+		t.Fatal(err)
+	}
+	if _, err := b.Unmarshal([]byte{0x14, 0x80}); err != nil { // 0x8014
+		t.Fatal(err)
+	}
+	if a.Equal(&b) {
+		t.Error("controls with different RawValue must not be Equal")
+	}
+}

--- a/securitydescriptor/control/NtSecurityDescriptorControl_functions.go
+++ b/securitydescriptor/control/NtSecurityDescriptorControl_functions.go
@@ -81,31 +81,11 @@ func (nsdc *NtSecurityDescriptorControl) Equal(other *NtSecurityDescriptorContro
 		return nsdc == other
 	}
 
-	if nsdc.RawValue != other.RawValue {
-		return false
-	}
-
-	if len(nsdc.Values) != len(other.Values) {
-		return false
-	}
-
-	if len(nsdc.Flags) != len(other.Flags) {
-		return false
-	}
-
-	// Compare Values slices
-	for i, value := range nsdc.Values {
-		if value != other.Values[i] {
-			return false
-		}
-	}
-
-	// Compare Flags slices
-	for i, flag := range nsdc.Flags {
-		if flag != other.Flags[i] {
-			return false
-		}
-	}
-
-	return true
+	// RawValue is the single 16-bit SECURITY_DESCRIPTOR_CONTROL word (MS-DTYP
+	// 2.4.6) and fully, canonically encodes the set of control bits. The Values
+	// and Flags slices are merely a derived, per-bit view built by Unmarshal via
+	// Go map iteration, whose order is randomized; comparing them positionally
+	// made two controls decoded from identical bytes compare unequal about half
+	// the time. Equality is therefore defined by RawValue alone.
+	return nsdc.RawValue == other.RawValue
 }


### PR DESCRIPTION
### Linked Issue
`Closes #114`

### Root Cause
`Equal` compared the `Values` and `Flags` slices element-by-element after checking `RawValue`. Those slices are populated by `Unmarshal` while ranging over the `NtSecurityDescriptorControlValueToShortName` map, and Go randomizes map iteration order — so two controls decoded from identical bytes hold the same bit set in a different slice order and the positional comparison returned `false`. The defect propagated through `NtSecurityDescriptorHeader.Equal` and `NtSecurityDescriptor.Equal`, making descriptor equality/involution intermittently and incorrectly false (measured ~238/500 for `0x8004`).

### Fix Description
`Equal` now returns `nsdc.RawValue == other.RawValue`. Per MS-DTYP 2.4.6 the Control field is a single 16-bit `SECURITY_DESCRIPTOR_CONTROL` word that fully and canonically encodes the set of `SE_*` bits; the `Values`/`Flags` slices are a derived per-bit view, so `RawValue` equality is necessary and sufficient. This mirrors the same fix class applied to the ACE-flag ordering bug.

### How Verified
- **Runtime:** decoding two controls from `{0x04, 0x80}` and comparing 1000 times now returns `Equal == true` every time; controls with different `RawValue` still compare unequal.
- **Tests:** `go test ./...` passes, including the existing control `Equal`/involution tests.

### Test Coverage
- **Added:** `securitydescriptor/control/NtSecurityDescriptorControl_equal_test.go` — `TestControl_Equal_Deterministic` (1000-iteration stability on a two-bit value) and `TestControl_Equal_DifferentValues`.

### Scope of Change
- **Files changed:** `securitydescriptor/control/NtSecurityDescriptorControl_functions.go`, `securitydescriptor/control/NtSecurityDescriptorControl_equal_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none.

### Risk and Rollout
Equality now depends only on the canonical `RawValue`; no false negatives, and no false positives (equal `RawValue` implies the same control set). Safe to merge.