### PR TITLE
[bug] Fix conditional-expression serializer Member_of braces and negative hex/octal base (Fixes #116)

### DIFF
--- a/ace/condition/serialize.go
+++ b/ace/condition/serialize.go
@@ -74,8 +74,15 @@ func serializeUnary(v *UnaryOp) string {
 	case tokenExists, tokenNotExists:
 		return operatorNames[v.Op] + " " + serializeNode(v.Operand, 0)
 	default:
-		// Member_of family: `Member_of {SID(...), ...}`.
-		return operatorNames[v.Op] + " " + serializeNode(v.Operand, 0)
+		// Member_of family: the SDDL text form requires the operand to be a
+		// brace-delimited SID array (`Member_of {SID(...), ...}`). The binary
+		// form also permits a bare SID literal operand (MS-DTYP 2.4.4.17.6), so
+		// wrap a non-composite operand in braces to produce re-parseable text.
+		operand := serializeNode(v.Operand, 0)
+		if _, isComposite := v.Operand.(*Composite); !isComposite {
+			operand = "{" + operand + "}"
+		}
+		return operatorNames[v.Op] + " " + operand
 	}
 }
 
@@ -110,25 +117,31 @@ func attributeText(a *Attribute) string {
 }
 
 func intText(v *IntLiteral) string {
+	// Format the magnitude in the recorded base, then re-apply the sign, so a
+	// negative hex/octal literal keeps its base (e.g. -0x5 stays hex) and its
+	// Base byte round-trips. uint64(-v.Value) yields the correct magnitude even
+	// for math.MinInt64 (two's-complement wraparound).
+	neg := v.Value < 0
+	var mag uint64
+	if neg {
+		mag = uint64(-v.Value)
+	} else {
+		mag = uint64(v.Value)
+	}
+
 	var body string
 	switch v.Base {
 	case baseHex:
-		if v.Value >= 0 {
-			body = "0x" + strconv.FormatInt(v.Value, 16)
-		} else {
-			body = strconv.FormatInt(v.Value, 10)
-		}
+		body = "0x" + strconv.FormatUint(mag, 16)
 	case baseOctal:
-		if v.Value >= 0 {
-			body = "0" + strconv.FormatInt(v.Value, 8)
-		} else {
-			body = strconv.FormatInt(v.Value, 10)
-		}
+		body = "0" + strconv.FormatUint(mag, 8)
 	default:
-		body = strconv.FormatInt(v.Value, 10)
+		body = strconv.FormatUint(mag, 10)
 	}
-	// A negative value already carries its '-'; only add an explicit '+'.
-	if v.Sign == signPositive && v.Value >= 0 {
+
+	if neg {
+		body = "-" + body
+	} else if v.Sign == signPositive {
 		body = "+" + body
 	}
 	return body

--- a/ace/condition/serialize_roundtrip_test.go
+++ b/ace/condition/serialize_roundtrip_test.go
@@ -1,0 +1,82 @@
+package condition_test
+
+import (
+	"encoding/hex"
+	"strings"
+	"testing"
+
+	"github.com/TheManticoreProject/winacl/ace/condition"
+)
+
+// TestMemberOf_BareSIDOperand_RoundTrips is a regression test for a Member_of
+// whose binary operand is a bare SID literal (spec-valid per MS-DTYP 2.4.4.17.6)
+// serializing to brace-less `Member_of SID(...)`, which the parser then could
+// not re-parse. The serializer must wrap it in a SID array.
+//
+// Hand-built wire: artx + SID literal (0x51, len 12, S-1-1-0) + Member_of (0x89) + padding.
+func TestMemberOf_BareSIDOperand_RoundTrips(t *testing.T) {
+	wire, err := hex.DecodeString("6172747851" + "0c000000" + "010100000000000100000000" + "89" + "0000")
+	if err != nil {
+		t.Fatalf("bad test hex: %v", err)
+	}
+
+	text, err := condition.Unmarshal(wire)
+	if err != nil {
+		t.Fatalf("Unmarshal error = %v", err)
+	}
+	if !strings.Contains(text, "{") || !strings.Contains(text, "}") {
+		t.Fatalf("Member_of operand not brace-wrapped: %q", text)
+	}
+
+	// The serialized text must now be re-parseable (previously errored).
+	bin, err := condition.Marshal(text)
+	if err != nil {
+		t.Fatalf("Marshal(%q) error = %v (serialized text is not re-parseable)", text, err)
+	}
+	// And it must be stable from here on.
+	text2, err := condition.Unmarshal(bin)
+	if err != nil {
+		t.Fatalf("re-Unmarshal error = %v", err)
+	}
+	if text != text2 {
+		t.Fatalf("text round-trip not stable: %q vs %q", text, text2)
+	}
+}
+
+// TestNegativeHexOctal_PreservesBase is a regression test for negative hex/octal
+// integer literals serializing as decimal, which lost the base byte on the
+// text round-trip.
+func TestNegativeHexOctal_PreservesBase(t *testing.T) {
+	cases := []struct {
+		expr string
+		want string
+	}{
+		{`(@User.count==-0x5)`, "-0x5"},
+		{`(@User.count==-010)`, "-010"},
+		{`(@User.count==0x1f)`, "0x1f"},
+		{`(@User.n==-5)`, "-5"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.expr, func(t *testing.T) {
+			bin1, err := condition.Marshal(tc.expr)
+			if err != nil {
+				t.Fatalf("Marshal error = %v", err)
+			}
+			text, err := condition.Unmarshal(bin1)
+			if err != nil {
+				t.Fatalf("Unmarshal error = %v", err)
+			}
+			if !strings.Contains(text, tc.want) {
+				t.Fatalf("serialized %q, want it to contain %q", text, tc.want)
+			}
+			// Binary round-trip via text must be byte-stable (base byte preserved).
+			bin2, err := condition.Marshal(text)
+			if err != nil {
+				t.Fatalf("re-Marshal error = %v", err)
+			}
+			if hex.EncodeToString(bin1) != hex.EncodeToString(bin2) {
+				t.Fatalf("base byte not preserved through text round-trip for %q:\n  %x\n  %x", tc.expr, bin1, bin2)
+			}
+		})
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #116`

### Root Cause
Two `ace/condition/serialize.go` defects:
1. `serializeUnary` rendered the `Member_of` family as `op + " " + serialize(operand)`. When the binary operand is a bare SID literal (spec-valid per MS-DTYP 2.4.4.17.6) rather than a composite, this produced `Member_of SID(...)` with no braces — which the parser rejects, since the SDDL ABNF requires a brace-delimited SID array. So `Unmarshal` could emit text its own `Marshal` refused.
2. `intText` only prepended the `0x`/`0` base prefix for non-negative values and fell back to decimal for negatives, so a negative hex/octal literal (`-0x5`) serialized as `-5` and lost its base byte when re-parsed.

### Fix Description
- `serializeUnary` now wraps a non-composite `Member_of` operand in `{ }`, so a bare-SID operand serializes as `Member_of {SID(...)}` and re-parses.
- `intText` now formats the magnitude in the recorded base and re-applies the sign, so negative hex/octal keep their base (`-0x5`, `-010`). It uses `uint64(-v.Value)` for the magnitude, which is correct even for `math.MinInt64`.

### How Verified
- **Runtime:** decoding a hand-built `Member_of` + bare `SID(S-1-1-0)` wire now serializes with braces and re-Marshals successfully (previously errored); `-0x5`/`-010` round-trip through text with a byte-stable binary encoding, and positive hex (`0x1f`) and decimal negatives (`-5`) are unchanged.
- **Tests:** `go test ./...` passes, including the existing condition round-trip matrix and known-answer tests.

### Test Coverage
- **Added:** `ace/condition/serialize_roundtrip_test.go` — `TestMemberOf_BareSIDOperand_RoundTrips` and `TestNegativeHexOctal_PreservesBase`.

### Scope of Change
- **Files changed:** `ace/condition/serialize.go`, `ace/condition/serialize_roundtrip_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none. Composite `Member_of` operands and non-negative / decimal integers serialize identically to before.

### Risk and Rollout
Local to the serializer; only brace-less `Member_of` output and negative hex/octal output change, both toward round-trippable forms. Safe to merge.