### PR TITLE
[bug] Fix resource-attribute parseIntAuto to accept MinInt64 TI values (Fixes #118)

### DIFF
--- a/ace/resourceattribute/minint_test.go
+++ b/ace/resourceattribute/minint_test.go
@@ -1,0 +1,63 @@
+package resourceattribute_test
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/TheManticoreProject/winacl/ace/resourceattribute"
+)
+
+// TestMinInt64_TI is a regression test for parseIntAuto rejecting the
+// most-negative INT64 value. A CLAIM_SECURITY_ATTRIBUTE_TYPE_INT64 (TI) value is
+// a signed LONG64 whose range includes -9223372036854775808.
+func TestMinInt64_TI(t *testing.T) {
+	cases := []struct {
+		text string
+		want int64
+	}{
+		{`"n",TI,0,-9223372036854775808`, -9223372036854775808}, // math.MinInt64
+		{`"n",TI,0,9223372036854775807`, 9223372036854775807},   // math.MaxInt64
+		{`"n",TI,0,-1`, -1},
+		{`"n",TI,0,0`, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.text, func(t *testing.T) {
+			bin, err := resourceattribute.Marshal(tc.text)
+			if err != nil {
+				t.Fatalf("Marshal(%q) error = %v", tc.text, err)
+			}
+			ra, err := resourceattribute.Decode(bin)
+			if err != nil {
+				t.Fatalf("Decode error = %v", err)
+			}
+			if len(ra.Ints) != 1 || ra.Ints[0] != tc.want {
+				t.Fatalf("decoded Ints = %v, want [%d]", ra.Ints, tc.want)
+			}
+		})
+	}
+
+	// The MinInt64 value must encode as the 8-byte LE 0x0000000000000080.
+	bin, err := resourceattribute.Marshal(`"n",TI,0,-9223372036854775808`)
+	if err != nil {
+		t.Fatalf("Marshal error = %v", err)
+	}
+	ra, _ := resourceattribute.Decode(bin)
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], uint64(ra.Ints[0]))
+	if buf != [8]byte{0, 0, 0, 0, 0, 0, 0, 0x80} {
+		t.Fatalf("MinInt64 encoded as %x, want 0000000000000080", buf)
+	}
+}
+
+// TestOverflow_TI verifies values beyond the signed 64-bit range are rejected.
+func TestOverflow_TI(t *testing.T) {
+	bad := []string{
+		`"n",TI,0,9223372036854775808`,  // 2^63, one past MaxInt64
+		`"n",TI,0,-9223372036854775809`, // one below MinInt64
+	}
+	for _, s := range bad {
+		if _, err := resourceattribute.Marshal(s); err == nil {
+			t.Errorf("Marshal(%q) expected an out-of-range error, got nil", s)
+		}
+	}
+}

--- a/ace/resourceattribute/resourceattribute.go
+++ b/ace/resourceattribute/resourceattribute.go
@@ -475,21 +475,33 @@ func parseIntAuto(s string) (int64, error) {
 	} else if strings.HasPrefix(body, "+") {
 		body = body[1:]
 	}
-	var v int64
-	var err error
-	switch {
-	case strings.HasPrefix(body, "0x") || strings.HasPrefix(body, "0X"):
-		v, err = strconv.ParseInt(body[2:], 16, 64)
-	default:
-		v, err = strconv.ParseInt(body, 10, 64)
+
+	// Parse the magnitude as an unsigned 64-bit value so the full signed LONG64
+	// range is reachable. Parsing the magnitude with strconv.ParseInt would
+	// reject the most-negative value (-9223372036854775808), whose magnitude
+	// 2^63 exceeds math.MaxInt64.
+	base := 10
+	if strings.HasPrefix(body, "0x") || strings.HasPrefix(body, "0X") {
+		base = 16
+		body = body[2:]
 	}
+	mag, err := strconv.ParseUint(body, base, 64)
 	if err != nil {
 		return 0, err
 	}
+
 	if neg {
-		v = -v
+		if mag > uint64(1)<<63 { // > 2^63, i.e. below math.MinInt64
+			return 0, fmt.Errorf("integer %q is out of the signed 64-bit range", s)
+		}
+		// int64(-mag) via unsigned two's-complement wraparound yields the correct
+		// value for every magnitude up to and including 2^63 (math.MinInt64).
+		return int64(-mag), nil
 	}
-	return v, nil
+	if mag > uint64(1)<<63-1 { // > 2^63-1, i.e. above math.MaxInt64
+		return 0, fmt.Errorf("integer %q is out of the signed 64-bit range", s)
+	}
+	return int64(mag), nil
 }
 
 func parseUintAuto(s string) (uint64, error) {


### PR DESCRIPTION
### Linked Issue
`Closes #118`

### Root Cause
`parseIntAuto` stripped a leading `-` and parsed the remaining magnitude with `strconv.ParseInt(magnitude, 10, 64)`, then negated. For `math.MinInt64` (`-9223372036854775808`) the magnitude is `2^63`, which exceeds `math.MaxInt64`, so `ParseInt` rejected it — even though it is a valid `CLAIM_SECURITY_ATTRIBUTE_TYPE_INT64` (LONG64) value per MS-DTYP 2.4.10.1.

### Fix Description
`parseIntAuto` now parses the magnitude as an unsigned 64-bit value (`strconv.ParseUint`), which can represent `2^63`, then applies the sign via two's-complement (`int64(-mag)`), which yields the correct value up to and including `math.MinInt64`. Explicit range checks reject magnitudes below `MinInt64` (> 2^63) and above `MaxInt64` (> 2^63-1). Decimal/hex base detection and the existing behavior for all other values are preserved.

### How Verified
- **Runtime:** `-9223372036854775808` now parses to `math.MinInt64` and encodes as `0x0000000000000080` (LE); `9223372036854775807`, `-1`, `0` are unchanged; `9223372036854775808` and `-9223372036854775809` are rejected as out of range.
- **Tests:** `go test ./...` passes.

### Test Coverage
- **Added:** `ace/resourceattribute/minint_test.go` — `TestMinInt64_TI` (boundary values + exact LE encoding) and `TestOverflow_TI` (out-of-range rejection).

### Scope of Change
- **Files changed:** `ace/resourceattribute/resourceattribute.go`, `ace/resourceattribute/minint_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none.

### Risk and Rollout
Local to `parseIntAuto`; extends the accepted range to the full signed 64-bit domain and adds explicit bounds. Safe to merge.