### PR TITLE
Store only the 4 mask bytes in AccessControlMask.RawBytes (Fixes #120)

### DIFF
--- a/ace/mask/AccessControlMask.go
+++ b/ace/mask/AccessControlMask.go
@@ -29,8 +29,12 @@ func (acm *AccessControlMask) Unmarshal(marshalledData []byte) (int, error) {
 		return 0, fmt.Errorf("AccessControlMask unmarshal requires at least 4 bytes, got %d", len(marshalledData))
 	}
 
-	// Store the raw bytes and set the size
-	acm.RawBytes = marshalledData
+	// Store exactly the 4 bytes of the ACCESS_MASK (MS-DTYP 2.4.3). The caller
+	// passes the whole remaining ACE body (mask + SID + application data), so
+	// slicing to [:4] avoids aliasing the variable-length remainder into
+	// RawBytes — which otherwise made Equal (a byte comparison of RawBytes)
+	// report two identical masks as unequal when their ACE tails differed.
+	acm.RawBytes = marshalledData[:4]
 	acm.RawBytesSize = 4
 
 	// Convert raw bytes to a uint32 value using little-endian format

--- a/ace/mask/AccessControlMask_rawbytes_test.go
+++ b/ace/mask/AccessControlMask_rawbytes_test.go
@@ -1,0 +1,33 @@
+package mask
+
+import (
+	"testing"
+)
+
+// TestAccessControlMask_Unmarshal_RawBytesFourBytes is a regression test for
+// Unmarshal aliasing the whole remaining ACE body into RawBytes. The ACCESS_MASK
+// is a fixed 4-byte field (MS-DTYP 2.4.3), so RawBytes must hold exactly those 4
+// bytes; otherwise Equal (a byte comparison of RawBytes) reports two masks with
+// the same value but different ACE tails as unequal.
+func TestAccessControlMask_Unmarshal_RawBytesFourBytes(t *testing.T) {
+	// 0x000f01ff followed by trailing bytes that belong to the SID / app data.
+	a := AccessControlMask{}
+	if _, err := a.Unmarshal([]byte{0xff, 0x01, 0x0f, 0x00, 0xaa, 0xbb, 0xcc, 0xdd}); err != nil {
+		t.Fatalf("Unmarshal error = %v", err)
+	}
+	b := AccessControlMask{}
+	if _, err := b.Unmarshal([]byte{0xff, 0x01, 0x0f, 0x00, 0x11, 0x22}); err != nil {
+		t.Fatalf("Unmarshal error = %v", err)
+	}
+
+	if len(a.RawBytes) != 4 {
+		t.Fatalf("RawBytes length = %d, want 4", len(a.RawBytes))
+	}
+	if a.RawValue != 0x000f01ff || b.RawValue != 0x000f01ff {
+		t.Fatalf("RawValue mismatch: 0x%08x / 0x%08x", a.RawValue, b.RawValue)
+	}
+	if !a.Equal(&b) {
+		t.Fatalf("masks with identical value 0x%08x but different ACE tails compare unequal (RawBytes %x vs %x)",
+			a.RawValue, a.RawBytes, b.RawBytes)
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #120`

### Root Cause
`AccessControlMask.Unmarshal` assigned `acm.RawBytes = marshalledData` — the whole slice passed by `AccessControlEntry.Unmarshal`, which is the post-header ACE body (mask + SID + application data) — rather than the 4 bytes of the fixed `ACCESS_MASK` field (MS-DTYP 2.4.3). `AccessControlMask.Equal` compares `RawBytes` with `bytes.Equal`, so two masks with the same `RawValue` but different ACE tails compared unequal.

### Fix Description
`Unmarshal` now stores `marshalledData[:4]` in `RawBytes` (the length check already guarantees ≥ 4 bytes). `RawValue` and `RawBytesSize` are unchanged. `Equal` therefore compares only the 4 canonical mask bytes.

### How Verified
- **Runtime:** two masks unmarshalled from `ff 01 0f 00` with different trailing bytes now both have `len(RawBytes) == 4`, `RawValue == 0x000f01ff`, and compare `Equal`; previously `Equal` returned false.
- **Tests:** `go test ./...` passes, including the existing mask involution/Equal tests.

### Test Coverage
- **Added:** `ace/mask/AccessControlMask_rawbytes_test.go` — `TestAccessControlMask_Unmarshal_RawBytesFourBytes`.

### Scope of Change
- **Files changed:** `ace/mask/AccessControlMask.go`, `ace/mask/AccessControlMask_rawbytes_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none. `RawValue`/`RawBytesSize`/return value are unchanged; only the aliased `RawBytes` contents are corrected.

### Risk and Rollout
Trivial and local; `RawBytes` now matches the documented 4-byte mask width. Safe to merge.