### PR TITLE
Describe ACE ApplicationData as a subtree with signature and decoded condition

### DIFF
--- a/ace/AccessControlEntry.go
+++ b/ace/AccessControlEntry.go
@@ -6,8 +6,10 @@ import (
 	"strings"
 
 	"github.com/TheManticoreProject/winacl/ace/acetype"
+	"github.com/TheManticoreProject/winacl/ace/condition"
 	"github.com/TheManticoreProject/winacl/ace/header"
 	"github.com/TheManticoreProject/winacl/ace/mask"
+	"github.com/TheManticoreProject/winacl/ace/resourceattribute"
 	"github.com/TheManticoreProject/winacl/identity"
 	"github.com/TheManticoreProject/winacl/object"
 )
@@ -946,8 +948,48 @@ func (ace *AccessControlEntry) Describe(indent int) {
 	}
 
 	if len(ace.ApplicationData) > 0 {
-		fmt.Printf("%s │ \x1b[93mApplicationData\x1b[0m : \x1b[96m%s\x1b[0m\n", indentPrompt, hex.EncodeToString(ace.ApplicationData))
+		ace.describeApplicationData(indent + 1)
 	}
 
 	fmt.Printf("%s └─\n", indentPrompt)
+}
+
+// describeApplicationData prints the ACE's ApplicationData as a subtree. For a
+// callback ACE carrying a conditional expression it shows the ACE_CONDITION
+// signature ("artx") magic bytes and the decoded expression; for a
+// resource-attribute ACE it shows the decoded CLAIM attribute; otherwise it
+// falls back to the raw bytes. The raw bytes are always shown so nothing is
+// hidden if decoding is partial.
+func (ace *AccessControlEntry) describeApplicationData(indent int) {
+	p := strings.Repeat(" │ ", indent)
+	rawHex := hex.EncodeToString(ace.ApplicationData)
+
+	fmt.Printf("%s\x1b[93m<ApplicationData>\x1b[0m\n", p)
+
+	switch {
+	case condition.IsConditional(ace.ApplicationData):
+		sig := ace.ApplicationData[:4]
+		fmt.Printf("%s │ \x1b[93mType\x1b[0m      : \x1b[94mConditional Expression\x1b[0m\n", p)
+		fmt.Printf("%s │ \x1b[93mSignature\x1b[0m : \x1b[96m0x%s\x1b[0m (\x1b[94m%s\x1b[0m)\n", p, hex.EncodeToString(sig), string(sig))
+		if expr, err := condition.Unmarshal(ace.ApplicationData); err == nil {
+			fmt.Printf("%s │ \x1b[93mCondition\x1b[0m : \x1b[96m(%s)\x1b[0m\n", p, expr)
+		} else {
+			fmt.Printf("%s │ \x1b[93mCondition\x1b[0m : \x1b[91m<unparsed: %s>\x1b[0m\n", p, err)
+		}
+		fmt.Printf("%s │ \x1b[93mRawBytes\x1b[0m  : \x1b[96m%s\x1b[0m\n", p, rawHex)
+
+	case ace.Header.Type.Value == acetype.ACE_TYPE_SYSTEM_RESOURCE_ATTRIBUTE:
+		fmt.Printf("%s │ \x1b[93mType\x1b[0m      : \x1b[94mResource Attribute (CLAIM_SECURITY_ATTRIBUTE_RELATIVE_V1)\x1b[0m\n", p)
+		if attr, err := resourceattribute.Unmarshal(ace.ApplicationData); err == nil {
+			fmt.Printf("%s │ \x1b[93mAttribute\x1b[0m : \x1b[96m(%s)\x1b[0m\n", p, attr)
+		} else {
+			fmt.Printf("%s │ \x1b[93mAttribute\x1b[0m : \x1b[91m<unparsed: %s>\x1b[0m\n", p, err)
+		}
+		fmt.Printf("%s │ \x1b[93mRawBytes\x1b[0m  : \x1b[96m%s\x1b[0m\n", p, rawHex)
+
+	default:
+		fmt.Printf("%s │ \x1b[93mRawBytes\x1b[0m : \x1b[96m%s\x1b[0m\n", p, rawHex)
+	}
+
+	fmt.Printf("%s └─\n", p)
 }

--- a/ace/AccessControlEntry_describe_test.go
+++ b/ace/AccessControlEntry_describe_test.go
@@ -1,0 +1,108 @@
+package ace_test
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/TheManticoreProject/winacl/ace"
+	"github.com/TheManticoreProject/winacl/ace/acetype"
+	"github.com/TheManticoreProject/winacl/ace/condition"
+	"github.com/TheManticoreProject/winacl/ace/resourceattribute"
+)
+
+// captureStdout runs f and returns everything it wrote to os.Stdout.
+func captureStdout(t *testing.T, f func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	done := make(chan string, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		done <- string(b)
+	}()
+	f()
+	w.Close()
+	os.Stdout = orig
+	return <-done
+}
+
+// TestDescribe_ApplicationData_Conditional verifies the ApplicationData subtree
+// shows the artx magic bytes and the decoded conditional expression.
+func TestDescribe_ApplicationData_Conditional(t *testing.T) {
+	appData, err := condition.Marshal(`(@User.Title=="PM" && @User.Division=="Finance")`)
+	if err != nil {
+		t.Fatalf("condition.Marshal error = %v", err)
+	}
+
+	a := &ace.AccessControlEntry{}
+	a.Header.Type.Value = acetype.ACE_TYPE_ACCESS_ALLOWED_CALLBACK
+	a.Identity.SID.FromString("S-1-1-0")
+	a.ApplicationData = appData
+
+	out := captureStdout(t, func() { a.Describe(0) })
+
+	for _, want := range []string{
+		"<ApplicationData>",
+		"Conditional Expression",
+		"Signature",
+		"0x61727478", // "artx" magic bytes
+		"artx",
+		`@User.Title == "PM"`,
+		`@User.Division == "Finance"`,
+		"RawBytes",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("Describe output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestDescribe_ApplicationData_ResourceAttribute verifies the subtree shows the
+// decoded CLAIM resource attribute.
+func TestDescribe_ApplicationData_ResourceAttribute(t *testing.T) {
+	appData, err := resourceattribute.Marshal(`"Project",TS,0,"Windows","SQL"`)
+	if err != nil {
+		t.Fatalf("resourceattribute.Marshal error = %v", err)
+	}
+
+	a := &ace.AccessControlEntry{}
+	a.Header.Type.Value = acetype.ACE_TYPE_SYSTEM_RESOURCE_ATTRIBUTE
+	a.Identity.SID.FromString("S-1-1-0")
+	a.ApplicationData = appData
+
+	out := captureStdout(t, func() { a.Describe(0) })
+
+	for _, want := range []string{
+		"<ApplicationData>",
+		"Resource Attribute",
+		`"Project"`,
+		"TS",
+		`"Windows"`,
+		`"SQL"`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("Describe output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestDescribe_ApplicationData_Raw verifies non-conditional/non-RA data falls
+// back to a raw-bytes line.
+func TestDescribe_ApplicationData_Raw(t *testing.T) {
+	a := &ace.AccessControlEntry{}
+	a.Header.Type.Value = acetype.ACE_TYPE_SYSTEM_SCOPED_POLICY_ID
+	a.Identity.SID.FromString("S-1-1-0")
+	a.ApplicationData = []byte{0xde, 0xad, 0xbe, 0xef}
+
+	out := captureStdout(t, func() { a.Describe(0) })
+
+	if !strings.Contains(out, "<ApplicationData>") || !strings.Contains(out, "deadbeef") {
+		t.Fatalf("Describe output missing raw ApplicationData subtree:\n%s", out)
+	}
+}


### PR DESCRIPTION
### Summary
`AccessControlEntry.Describe` previously rendered `ApplicationData` as a single opaque hex line. It now renders a subtree that decodes the field: for a callback ACE carrying a conditional expression it shows the `ACE_CONDITION_SIGNATURE` ("artx") magic bytes and the decoded expression; for a resource-attribute ACE it shows the decoded CLAIM attribute; otherwise it falls back to raw bytes. The raw bytes are always included so nothing is hidden.

### What changed
- New helper `AccessControlEntry.describeApplicationData(indent)` prints an `<ApplicationData>` subtree consistent with the existing Describe formatting (indentation, box-drawing, colors).
  - **Conditional (callback) ACE** — `Type: Conditional Expression`, `Signature: 0x61727478 (artx)`, `Condition: (<decoded SDDL expression>)`, `RawBytes`.
  - **Resource-attribute ACE** — `Type: Resource Attribute (CLAIM_SECURITY_ATTRIBUTE_RELATIVE_V1)`, `Attribute: ("name",TYPE,flags,values)`, `RawBytes`.
  - **Other** (e.g. scoped-policy-id) — `RawBytes` only.
  - If decoding fails, an `<unparsed: ...>` note is shown and the raw bytes are still printed.

### Example output
```
 │ <ApplicationData>
 │  │ Type      : Conditional Expression
 │  │ Signature : 0x61727478 (artx)
 │  │ Condition : (@User.Title == "PM" && (@User.Division == "Finance" || Member_of {SID(S-1-5-32-544)}))
 │  │ RawBytes  : 61727478f90a...
 │  └─

 │ <ApplicationData>
 │  │ Type      : Resource Attribute (CLAIM_SECURITY_ATTRIBUTE_RELATIVE_V1)
 │  │ Attribute : ("Project",TS,0,"Windows","SQL")
 │  │ RawBytes  : 180000000300...
 │  └─
```

### How Verified
- **Runtime:** rendered conditional, resource-attribute, and raw ApplicationData ACEs and confirmed the subtree contents (signature bytes, decoded expression/attribute).
- **Tests:** `go test ./...` passes.

### Test Coverage
- **Added:** `ace/AccessControlEntry_describe_test.go` — captures `Describe` output and asserts the conditional subtree (artx signature + decoded expression), the resource-attribute subtree, and the raw-bytes fallback.

### Scope of Change
- **Files changed:** `ace/AccessControlEntry.go`, `ace/AccessControlEntry_describe_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none — only `Describe`'s ApplicationData rendering changed; it reuses the existing `condition` and `resourceattribute` decoders (no import cycle).

### Notes
Output is display-only; parsing/serialization behavior is unchanged.