### PR TITLE
Split Describe into DescribeList/DescribeWithCallback/Describe (Fixes #125)

### DIFF
--- a/ace/AccessControlEntry.go
+++ b/ace/AccessControlEntry.go
@@ -2,7 +2,6 @@ package ace
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/TheManticoreProject/winacl/ace/acetype"
 	"github.com/TheManticoreProject/winacl/ace/applicationdata"
@@ -10,6 +9,7 @@ import (
 	"github.com/TheManticoreProject/winacl/ace/mask"
 	"github.com/TheManticoreProject/winacl/identity"
 	"github.com/TheManticoreProject/winacl/object"
+	"github.com/TheManticoreProject/winacl/utils/describe"
 )
 
 // AccessControlEntry represents an entry in an access control list (ACL).
@@ -867,90 +867,86 @@ func (ace *AccessControlEntry) Marshal() ([]byte, error) {
 	return marshalledData, nil
 }
 
-// Describe prints a detailed description of the AccessControlEntry struct,
-// including its attributes formatted with indentation for clarity.
-//
-// Parameters:
-//   - indent (int): The indentation level for formatting the output. Each level increases
-//     the indentation depth, allowing for a hierarchical display of the ACE's components.
-func (ace *AccessControlEntry) Describe(indent int) {
-	indentPrompt := strings.Repeat(" │ ", indent)
+// DescribeList returns a detailed description of the AccessControlEntry as a
+// list of lines at indentation depth 0, nesting each component (header, mask,
+// object type, identity, application data) one level deeper.
+func (ace *AccessControlEntry) DescribeList() []string {
+	lines := []string{fmt.Sprintf("<AccessControlEntry #%d>", ace.Index)}
 
-	fmt.Printf("%s<AccessControlEntry #%d>\n", indentPrompt, ace.Index)
-	ace.Header.Describe(indent + 1)
+	lines = append(lines, describe.Nest(ace.Header.DescribeList())...)
 
 	switch ace.Header.Type.Value {
 
 	case acetype.ACE_TYPE_ACCESS_ALLOWED:
-		ace.Mask.Describe(indent + 1)
-		ace.Identity.Describe(indent + 1)
+		lines = append(lines, describe.Nest(ace.Mask.DescribeList())...)
+		lines = append(lines, describe.Nest(ace.Identity.DescribeList())...)
 
 	case acetype.ACE_TYPE_ACCESS_DENIED:
-		ace.Mask.Describe(indent + 1)
-		ace.Identity.Describe(indent + 1)
+		lines = append(lines, describe.Nest(ace.Mask.DescribeList())...)
+		lines = append(lines, describe.Nest(ace.Identity.DescribeList())...)
 
 	case acetype.ACE_TYPE_SYSTEM_AUDIT:
-		ace.Mask.Describe(indent + 1)
-		ace.Identity.Describe(indent + 1)
+		lines = append(lines, describe.Nest(ace.Mask.DescribeList())...)
+		lines = append(lines, describe.Nest(ace.Identity.DescribeList())...)
 
 	case acetype.ACE_TYPE_SYSTEM_ALARM:
 	case acetype.ACE_TYPE_ACCESS_ALLOWED_COMPOUND:
 	case acetype.ACE_TYPE_ACCESS_ALLOWED_OBJECT:
-		ace.Mask.Describe(indent + 1)
-		ace.AccessControlObjectType.Describe(indent + 1)
-		ace.Identity.Describe(indent + 1)
+		lines = append(lines, describe.Nest(ace.Mask.DescribeList())...)
+		lines = append(lines, describe.Nest(ace.AccessControlObjectType.DescribeList())...)
+		lines = append(lines, describe.Nest(ace.Identity.DescribeList())...)
 
 	case acetype.ACE_TYPE_ACCESS_DENIED_OBJECT:
-		ace.Mask.Describe(indent + 1)
-		ace.AccessControlObjectType.Describe(indent + 1)
-		ace.Identity.Describe(indent + 1)
+		lines = append(lines, describe.Nest(ace.Mask.DescribeList())...)
+		lines = append(lines, describe.Nest(ace.AccessControlObjectType.DescribeList())...)
+		lines = append(lines, describe.Nest(ace.Identity.DescribeList())...)
 
 	case acetype.ACE_TYPE_SYSTEM_AUDIT_OBJECT:
-		ace.Mask.Describe(indent + 1)
-		ace.AccessControlObjectType.Describe(indent + 1)
-		ace.Identity.Describe(indent + 1)
+		lines = append(lines, describe.Nest(ace.Mask.DescribeList())...)
+		lines = append(lines, describe.Nest(ace.AccessControlObjectType.DescribeList())...)
+		lines = append(lines, describe.Nest(ace.Identity.DescribeList())...)
 
 	case acetype.ACE_TYPE_SYSTEM_ALARM_OBJECT:
 	case acetype.ACE_TYPE_ACCESS_ALLOWED_CALLBACK:
-		ace.Mask.Describe(indent + 1)
-		ace.Identity.Describe(indent + 1)
+		lines = append(lines, describe.Nest(ace.Mask.DescribeList())...)
+		lines = append(lines, describe.Nest(ace.Identity.DescribeList())...)
 
 	case acetype.ACE_TYPE_ACCESS_DENIED_CALLBACK:
-		ace.Mask.Describe(indent + 1)
-		ace.Identity.Describe(indent + 1)
+		lines = append(lines, describe.Nest(ace.Mask.DescribeList())...)
+		lines = append(lines, describe.Nest(ace.Identity.DescribeList())...)
 
 	case acetype.ACE_TYPE_ACCESS_ALLOWED_CALLBACK_OBJECT:
-		ace.Mask.Describe(indent + 1)
-		ace.AccessControlObjectType.Describe(indent + 1)
-		ace.Identity.Describe(indent + 1)
+		lines = append(lines, describe.Nest(ace.Mask.DescribeList())...)
+		lines = append(lines, describe.Nest(ace.AccessControlObjectType.DescribeList())...)
+		lines = append(lines, describe.Nest(ace.Identity.DescribeList())...)
 
 	case acetype.ACE_TYPE_ACCESS_DENIED_CALLBACK_OBJECT:
-		ace.Mask.Describe(indent + 1)
-		ace.AccessControlObjectType.Describe(indent + 1)
-		ace.Identity.Describe(indent + 1)
+		lines = append(lines, describe.Nest(ace.Mask.DescribeList())...)
+		lines = append(lines, describe.Nest(ace.AccessControlObjectType.DescribeList())...)
+		lines = append(lines, describe.Nest(ace.Identity.DescribeList())...)
 
 	case acetype.ACE_TYPE_SYSTEM_AUDIT_CALLBACK:
-		ace.Mask.Describe(indent + 1)
-		ace.Identity.Describe(indent + 1)
+		lines = append(lines, describe.Nest(ace.Mask.DescribeList())...)
+		lines = append(lines, describe.Nest(ace.Identity.DescribeList())...)
 
 	case acetype.ACE_TYPE_SYSTEM_ALARM_CALLBACK:
 	case acetype.ACE_TYPE_SYSTEM_AUDIT_CALLBACK_OBJECT:
-		ace.Mask.Describe(indent + 1)
-		ace.AccessControlObjectType.Describe(indent + 1)
-		ace.Identity.Describe(indent + 1)
+		lines = append(lines, describe.Nest(ace.Mask.DescribeList())...)
+		lines = append(lines, describe.Nest(ace.AccessControlObjectType.DescribeList())...)
+		lines = append(lines, describe.Nest(ace.Identity.DescribeList())...)
 
 	case acetype.ACE_TYPE_SYSTEM_ALARM_CALLBACK_OBJECT:
 	case acetype.ACE_TYPE_SYSTEM_MANDATORY_LABEL:
-		ace.Mask.Describe(indent + 1)
-		ace.Identity.Describe(indent + 1)
+		lines = append(lines, describe.Nest(ace.Mask.DescribeList())...)
+		lines = append(lines, describe.Nest(ace.Identity.DescribeList())...)
 
 	case acetype.ACE_TYPE_SYSTEM_RESOURCE_ATTRIBUTE:
-		ace.Mask.Describe(indent + 1)
-		ace.Identity.Describe(indent + 1)
+		lines = append(lines, describe.Nest(ace.Mask.DescribeList())...)
+		lines = append(lines, describe.Nest(ace.Identity.DescribeList())...)
 
 	case acetype.ACE_TYPE_SYSTEM_SCOPED_POLICY_ID:
-		ace.Mask.Describe(indent + 1)
-		ace.Identity.Describe(indent + 1)
+		lines = append(lines, describe.Nest(ace.Mask.DescribeList())...)
+		lines = append(lines, describe.Nest(ace.Identity.DescribeList())...)
 	}
 
 	if ace.ApplicationData.Len() > 0 {
@@ -958,8 +954,26 @@ func (ace *AccessControlEntry) Describe(indent int) {
 		// correct interpretation (resource attribute vs. raw) even when the caller
 		// populated RawBytes directly.
 		ace.ApplicationData.AceType = ace.Header.Type.Value
-		ace.ApplicationData.Describe(indent + 1)
+		lines = append(lines, describe.Nest(ace.ApplicationData.DescribeList())...)
 	}
 
-	fmt.Printf("%s └─\n", indentPrompt)
+	lines = append(lines, " └─")
+
+	return lines
+}
+
+// DescribeWithCallback renders the AccessControlEntry at the given indentation
+// depth, routing each line to the provided fmt.Printf-like callback.
+func (ace *AccessControlEntry) DescribeWithCallback(indent int, printf describe.Printf) {
+	describe.WithCallback(indent, ace.DescribeList(), printf)
+}
+
+// Describe prints a detailed description of the AccessControlEntry struct,
+// including its attributes formatted with indentation for clarity.
+//
+// Parameters:
+//   - indent (int): The indentation level for formatting the output. Each level increases
+//     the indentation depth, allowing for a hierarchical display of the ACE's components.
+func (ace *AccessControlEntry) Describe(indent int) {
+	ace.DescribeWithCallback(indent, fmt.Printf)
 }

--- a/ace/applicationdata/ApplicationData.go
+++ b/ace/applicationdata/ApplicationData.go
@@ -20,11 +20,11 @@ import (
 	"bytes"
 	"encoding/hex"
 	"fmt"
-	"strings"
 
 	"github.com/TheManticoreProject/winacl/ace/acetype"
 	"github.com/TheManticoreProject/winacl/ace/condition"
 	"github.com/TheManticoreProject/winacl/ace/resourceattribute"
+	"github.com/TheManticoreProject/winacl/utils/describe"
 )
 
 // ApplicationData holds the trailing ApplicationData bytes of an ACE together
@@ -119,44 +119,53 @@ func (ad *ApplicationData) Equal(other *ApplicationData) bool {
 	return bytes.Equal(ad.RawBytes, other.RawBytes)
 }
 
-// Describe prints the ApplicationData as a subtree. For a callback ACE carrying
-// a conditional expression it shows the ACE_CONDITION signature ("artx") magic
-// bytes and the decoded expression; for a resource-attribute ACE it shows the
-// decoded CLAIM attribute; otherwise it falls back to the raw bytes. The raw
-// bytes are always shown so nothing is hidden if decoding is partial.
-//
-// Parameters:
-//   - indent (int): The indentation level for formatting the output.
-func (ad *ApplicationData) Describe(indent int) {
-	p := strings.Repeat(" │ ", indent)
+// DescribeList returns the ApplicationData description as a list of lines at
+// indentation depth 0. For a callback ACE carrying a conditional expression it
+// shows the ACE_CONDITION signature ("artx") magic bytes and the decoded
+// expression; for a resource-attribute ACE it shows the decoded CLAIM
+// attribute; otherwise it falls back to the raw bytes. The raw bytes are always
+// shown so nothing is hidden if decoding is partial.
+func (ad *ApplicationData) DescribeList() []string {
 	rawHex := hex.EncodeToString(ad.RawBytes)
 
-	fmt.Printf("%s<ApplicationData>\n", p)
+	lines := []string{"<ApplicationData>"}
 
 	switch {
 	case ad.IsConditional():
 		sig := ad.RawBytes[:4]
-		fmt.Printf("%s │ \x1b[93mType\x1b[0m      : \x1b[94mConditional Expression\x1b[0m\n", p)
-		fmt.Printf("%s │ \x1b[93mSignature\x1b[0m : \x1b[96m0x%s\x1b[0m (\x1b[94m%s\x1b[0m)\n", p, hex.EncodeToString(sig), string(sig))
+		lines = append(lines, " │ \x1b[93mType\x1b[0m      : \x1b[94mConditional Expression\x1b[0m")
+		lines = append(lines, fmt.Sprintf(" │ \x1b[93mSignature\x1b[0m : \x1b[96m0x%s\x1b[0m (\x1b[94m%s\x1b[0m)", hex.EncodeToString(sig), string(sig)))
 		if expr, err := ad.ConditionalExpression(); err == nil {
-			fmt.Printf("%s │ \x1b[93mCondition\x1b[0m : \x1b[96m(%s)\x1b[0m\n", p, expr)
+			lines = append(lines, fmt.Sprintf(" │ \x1b[93mCondition\x1b[0m : \x1b[96m(%s)\x1b[0m", expr))
 		} else {
-			fmt.Printf("%s │ \x1b[93mCondition\x1b[0m : \x1b[91m<unparsed: %s>\x1b[0m\n", p, err)
+			lines = append(lines, fmt.Sprintf(" │ \x1b[93mCondition\x1b[0m : \x1b[91m<unparsed: %s>\x1b[0m", err))
 		}
-		fmt.Printf("%s │ \x1b[93mRawBytes\x1b[0m  : \x1b[96m%s\x1b[0m\n", p, rawHex)
+		lines = append(lines, fmt.Sprintf(" │ \x1b[93mRawBytes\x1b[0m  : \x1b[96m%s\x1b[0m", rawHex))
 
 	case ad.IsResourceAttribute():
-		fmt.Printf("%s │ \x1b[93mType\x1b[0m      : \x1b[94mResource Attribute (CLAIM_SECURITY_ATTRIBUTE_RELATIVE_V1)\x1b[0m\n", p)
+		lines = append(lines, " │ \x1b[93mType\x1b[0m      : \x1b[94mResource Attribute (CLAIM_SECURITY_ATTRIBUTE_RELATIVE_V1)\x1b[0m")
 		if attr, err := ad.ResourceAttribute(); err == nil {
-			fmt.Printf("%s │ \x1b[93mAttribute\x1b[0m : \x1b[96m(%s)\x1b[0m\n", p, attr)
+			lines = append(lines, fmt.Sprintf(" │ \x1b[93mAttribute\x1b[0m : \x1b[96m(%s)\x1b[0m", attr))
 		} else {
-			fmt.Printf("%s │ \x1b[93mAttribute\x1b[0m : \x1b[91m<unparsed: %s>\x1b[0m\n", p, err)
+			lines = append(lines, fmt.Sprintf(" │ \x1b[93mAttribute\x1b[0m : \x1b[91m<unparsed: %s>\x1b[0m", err))
 		}
-		fmt.Printf("%s │ \x1b[93mRawBytes\x1b[0m  : \x1b[96m%s\x1b[0m\n", p, rawHex)
+		lines = append(lines, fmt.Sprintf(" │ \x1b[93mRawBytes\x1b[0m  : \x1b[96m%s\x1b[0m", rawHex))
 
 	default:
-		fmt.Printf("%s │ \x1b[93mRawBytes\x1b[0m : \x1b[96m%s\x1b[0m\n", p, rawHex)
+		lines = append(lines, fmt.Sprintf(" │ \x1b[93mRawBytes\x1b[0m : \x1b[96m%s\x1b[0m", rawHex))
 	}
 
-	fmt.Printf("%s └─\n", p)
+	lines = append(lines, " └─")
+
+	return lines
+}
+
+// DescribeWithCallback renders the ApplicationData at the given indentation
+// depth, routing each line to the provided fmt.Printf-like callback.
+func (ad *ApplicationData) DescribeWithCallback(indent int, printf describe.Printf) {
+	describe.WithCallback(indent, ad.DescribeList(), printf)
+}
+
+func (ad *ApplicationData) Describe(indent int) {
+	ad.DescribeWithCallback(indent, fmt.Printf)
 }

--- a/ace/header/AccessControlEntryHeader.go
+++ b/ace/header/AccessControlEntryHeader.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/TheManticoreProject/winacl/ace/aceflags"
 	"github.com/TheManticoreProject/winacl/ace/acetype"
+	"github.com/TheManticoreProject/winacl/utils/describe"
 )
 
 // AccessControlEntryHeader represents the header of an Access Control Entry (ACE)
@@ -117,11 +118,25 @@ func (aceheader *AccessControlEntryHeader) Marshal() ([]byte, error) {
 // Parameters:
 //   - indent: An integer that specifies the level of indentation for the output,
 //     allowing for better visualization of nested structures.
+//
+// DescribeList returns the AccessControlEntryHeader description as a list of
+// lines at indentation depth 0.
+func (aceheader *AccessControlEntryHeader) DescribeList() []string {
+	return []string{
+		"<AccessControlEntryHeader>",
+		fmt.Sprintf(" │ \x1b[93mType\x1b[0m  : \x1b[96m0x%02x\x1b[0m (\x1b[94m%s\x1b[0m)", aceheader.Type.Value, aceheader.Type.String()),
+		fmt.Sprintf(" │ \x1b[93mFlags\x1b[0m : \x1b[96m0x%02x\x1b[0m (\x1b[94m%s\x1b[0m)", aceheader.Flags.RawValue, strings.Join(aceheader.Flags.Flags, "|")),
+		fmt.Sprintf(" │ \x1b[93mSize\x1b[0m  : \x1b[96m0x%04x\x1b[0m", aceheader.Size),
+		" └─",
+	}
+}
+
+// DescribeWithCallback renders the AccessControlEntryHeader at the given
+// indentation depth, routing each line to the provided fmt.Printf-like callback.
+func (aceheader *AccessControlEntryHeader) DescribeWithCallback(indent int, printf describe.Printf) {
+	describe.WithCallback(indent, aceheader.DescribeList(), printf)
+}
+
 func (aceheader *AccessControlEntryHeader) Describe(indent int) {
-	indentPrompt := strings.Repeat(" │ ", indent)
-	fmt.Printf("%s<AccessControlEntryHeader>\n", indentPrompt)
-	fmt.Printf("%s │ \x1b[93mType\x1b[0m  : \x1b[96m0x%02x\x1b[0m (\x1b[94m%s\x1b[0m)\n", indentPrompt, aceheader.Type.Value, aceheader.Type.String())
-	fmt.Printf("%s │ \x1b[93mFlags\x1b[0m : \x1b[96m0x%02x\x1b[0m (\x1b[94m%s\x1b[0m)\n", indentPrompt, aceheader.Flags.RawValue, strings.Join(aceheader.Flags.Flags, "|"))
-	fmt.Printf("%s │ \x1b[93mSize\x1b[0m  : \x1b[96m0x%04x\x1b[0m\n", indentPrompt, aceheader.Size)
-	fmt.Printf("%s └─\n", indentPrompt)
+	aceheader.DescribeWithCallback(indent, fmt.Printf)
 }

--- a/ace/mask/AccessControlMask.go
+++ b/ace/mask/AccessControlMask.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/TheManticoreProject/winacl/rights"
+	"github.com/TheManticoreProject/winacl/utils/describe"
 )
 
 // AccessControlMask represents a mask for access control entries.
@@ -84,11 +85,24 @@ func (acm *AccessControlMask) String() string {
 	return strings.Join(acm.Flags, "|")
 }
 
+// DescribeList returns the AccessControlMask description as a list of lines at
+// indentation depth 0.
+func (acm *AccessControlMask) DescribeList() []string {
+	return []string{
+		"<AccessControlMask>",
+		fmt.Sprintf(" │ \x1b[93mMask\x1b[0m : \x1b[96m0x%08x\x1b[0m (\x1b[94m%s\x1b[0m)", acm.RawValue, acm.String()),
+		" └─",
+	}
+}
+
+// DescribeWithCallback renders the AccessControlMask at the given indentation
+// depth, routing each line to the provided fmt.Printf-like callback.
+func (acm *AccessControlMask) DescribeWithCallback(indent int, printf describe.Printf) {
+	describe.WithCallback(indent, acm.DescribeList(), printf)
+}
+
 // Describe outputs the AccessControlMask details in a formatted manner.
 // It displays the raw mask value and the associated flags.
 func (acm *AccessControlMask) Describe(indent int) {
-	indentPrompt := strings.Repeat(" │ ", indent)
-	fmt.Printf("%s<AccessControlMask>\n", indentPrompt)
-	fmt.Printf("%s │ \x1b[93mMask\x1b[0m : \x1b[96m0x%08x\x1b[0m (\x1b[94m%s\x1b[0m)\n", indentPrompt, acm.RawValue, acm.String())
-	fmt.Printf("%s └─\n", indentPrompt)
+	acm.DescribeWithCallback(indent, fmt.Printf)
 }

--- a/acl/DiscretionaryAccessControlList.go
+++ b/acl/DiscretionaryAccessControlList.go
@@ -2,9 +2,9 @@ package acl
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/TheManticoreProject/winacl/ace"
+	"github.com/TheManticoreProject/winacl/utils/describe"
 )
 
 // DiscretionaryAccessControlList represents a Discretionary Access Control List (DACL).
@@ -95,22 +95,29 @@ func (dacl *DiscretionaryAccessControlList) Marshal() ([]byte, error) {
 	return marshalledData, nil
 }
 
-// Describe prints a detailed description of the DiscretionaryAccessControlList struct,
-// including its attributes formatted with indentation for clarity.
-//
-// Parameters:
-//   - indent (int): The indentation level for formatting the output. Each level increases
-//     the indentation depth, allowing for a hierarchical display of the DACL's components.
-func (dacl *DiscretionaryAccessControlList) Describe(indent int) {
-	indentPrompt := strings.Repeat(" │ ", indent)
+// DescribeList returns the DiscretionaryAccessControlList description as a list
+// of lines at indentation depth 0, nesting the header and each entry one level
+// deeper.
+func (dacl *DiscretionaryAccessControlList) DescribeList() []string {
+	lines := []string{"<DiscretionaryAccessControlList>"}
 
-	fmt.Printf("%s<DiscretionaryAccessControlList>\n", indentPrompt)
-
-	dacl.Header.Describe(indent + 1)
+	lines = append(lines, describe.Nest(dacl.Header.DescribeList())...)
 
 	for _, ace := range dacl.Entries {
-		ace.Describe(indent + 1)
+		lines = append(lines, describe.Nest(ace.DescribeList())...)
 	}
 
-	fmt.Printf("%s └─\n", indentPrompt)
+	lines = append(lines, " └─")
+
+	return lines
+}
+
+// DescribeWithCallback renders the DiscretionaryAccessControlList at the given
+// indentation depth, routing each line to the provided fmt.Printf-like callback.
+func (dacl *DiscretionaryAccessControlList) DescribeWithCallback(indent int, printf describe.Printf) {
+	describe.WithCallback(indent, dacl.DescribeList(), printf)
+}
+
+func (dacl *DiscretionaryAccessControlList) Describe(indent int) {
+	dacl.DescribeWithCallback(indent, fmt.Printf)
 }

--- a/acl/DiscretionaryAccessControlListHeader.go
+++ b/acl/DiscretionaryAccessControlListHeader.go
@@ -3,9 +3,9 @@ package acl
 import (
 	"encoding/binary"
 	"fmt"
-	"strings"
 
 	"github.com/TheManticoreProject/winacl/acl/revision"
+	"github.com/TheManticoreProject/winacl/utils/describe"
 )
 
 // DiscretionaryAccessControlListHeader represents the header of a Discretionary Access Control List (DACL).
@@ -96,19 +96,27 @@ func (daclheader *DiscretionaryAccessControlListHeader) Marshal() ([]byte, error
 	return marshalledData, nil
 }
 
-// Describe prints a detailed description of the DiscretionaryAccessControlListHeader struct,
-// including its attributes formatted with indentation for clarity.
-//
-// Parameters:
-//   - indent (int): The indentation level for formatting the output. Each level increases
-//     the indentation depth, allowing for a hierarchical display of the DACL's components.
+// DescribeList returns the DiscretionaryAccessControlListHeader description as a
+// list of lines at indentation depth 0.
+func (daclheader *DiscretionaryAccessControlListHeader) DescribeList() []string {
+	return []string{
+		"<DiscretionaryAccessControlListHeader>",
+		fmt.Sprintf(" │ \x1b[93mRevision\x1b[0m : \x1b[96m0x%02x\x1b[0m (\x1b[94m%s\x1b[0m)", daclheader.Revision.Value, daclheader.Revision.String()),
+		fmt.Sprintf(" │ \x1b[93mSbz1\x1b[0m     : \x1b[96m0x%02x\x1b[0m", daclheader.Sbz1),
+		fmt.Sprintf(" │ \x1b[93mAclSize\x1b[0m  : \x1b[96m0x%04x\x1b[0m", daclheader.AclSize),
+		fmt.Sprintf(" │ \x1b[93mAceCount\x1b[0m : \x1b[96m0x%04x (%d)\x1b[0m", daclheader.AceCount, daclheader.AceCount),
+		fmt.Sprintf(" │ \x1b[93mSbz2\x1b[0m     : \x1b[96m0x%04x\x1b[0m", daclheader.Sbz2),
+		" └─",
+	}
+}
+
+// DescribeWithCallback renders the DiscretionaryAccessControlListHeader at the
+// given indentation depth, routing each line to the provided fmt.Printf-like
+// callback.
+func (daclheader *DiscretionaryAccessControlListHeader) DescribeWithCallback(indent int, printf describe.Printf) {
+	describe.WithCallback(indent, daclheader.DescribeList(), printf)
+}
+
 func (daclheader *DiscretionaryAccessControlListHeader) Describe(indent int) {
-	indentPrompt := strings.Repeat(" │ ", indent)
-	fmt.Printf("%s<DiscretionaryAccessControlListHeader>\n", indentPrompt)
-	fmt.Printf("%s │ \x1b[93mRevision\x1b[0m : \x1b[96m0x%02x\x1b[0m (\x1b[94m%s\x1b[0m)\n", indentPrompt, daclheader.Revision.Value, daclheader.Revision.String())
-	fmt.Printf("%s │ \x1b[93mSbz1\x1b[0m     : \x1b[96m0x%02x\x1b[0m\n", indentPrompt, daclheader.Sbz1)
-	fmt.Printf("%s │ \x1b[93mAclSize\x1b[0m  : \x1b[96m0x%04x\x1b[0m\n", indentPrompt, daclheader.AclSize)
-	fmt.Printf("%s │ \x1b[93mAceCount\x1b[0m : \x1b[96m0x%04x (%d)\x1b[0m\n", indentPrompt, daclheader.AceCount, daclheader.AceCount)
-	fmt.Printf("%s │ \x1b[93mSbz2\x1b[0m     : \x1b[96m0x%04x\x1b[0m\n", indentPrompt, daclheader.Sbz2)
-	fmt.Printf("%s └─\n", indentPrompt)
+	daclheader.DescribeWithCallback(indent, fmt.Printf)
 }

--- a/acl/SystemAccessControlList.go
+++ b/acl/SystemAccessControlList.go
@@ -2,9 +2,9 @@ package acl
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/TheManticoreProject/winacl/ace"
+	"github.com/TheManticoreProject/winacl/utils/describe"
 )
 
 // SystemAccessControlList represents a System Access Control List (SACL).
@@ -97,22 +97,29 @@ func (sacl *SystemAccessControlList) Marshal() ([]byte, error) {
 	return marshalledData, nil
 }
 
-// Describe prints a detailed description of the SystemAccessControlList struct,
-// including its attributes formatted with indentation for clarity.
-//
-// Parameters:
-//   - indent (int): The indentation level for formatting the output. Each level increases
-//     the indentation depth, allowing for a hierarchical display of the SACL's components.
-func (sacl *SystemAccessControlList) Describe(indent int) {
-	indentPrompt := strings.Repeat(" │ ", indent)
+// DescribeList returns the SystemAccessControlList description as a list of
+// lines at indentation depth 0, nesting the header and each entry one level
+// deeper.
+func (sacl *SystemAccessControlList) DescribeList() []string {
+	lines := []string{"<SystemAccessControlList>"}
 
-	fmt.Printf("%s<SystemAccessControlList>\n", indentPrompt)
-
-	sacl.Header.Describe(indent + 1)
+	lines = append(lines, describe.Nest(sacl.Header.DescribeList())...)
 
 	for _, ace := range sacl.Entries {
-		ace.Describe(indent + 1)
+		lines = append(lines, describe.Nest(ace.DescribeList())...)
 	}
 
-	fmt.Printf("%s └─\n", indentPrompt)
+	lines = append(lines, " └─")
+
+	return lines
+}
+
+// DescribeWithCallback renders the SystemAccessControlList at the given
+// indentation depth, routing each line to the provided fmt.Printf-like callback.
+func (sacl *SystemAccessControlList) DescribeWithCallback(indent int, printf describe.Printf) {
+	describe.WithCallback(indent, sacl.DescribeList(), printf)
+}
+
+func (sacl *SystemAccessControlList) Describe(indent int) {
+	sacl.DescribeWithCallback(indent, fmt.Printf)
 }

--- a/acl/SystemAccessControlListHeader.go
+++ b/acl/SystemAccessControlListHeader.go
@@ -3,9 +3,9 @@ package acl
 import (
 	"encoding/binary"
 	"fmt"
-	"strings"
 
 	"github.com/TheManticoreProject/winacl/acl/revision"
+	"github.com/TheManticoreProject/winacl/utils/describe"
 )
 
 // SystemAccessControlListHeader represents the header of a System Access Control List (SACL).
@@ -93,19 +93,26 @@ func (saclheader *SystemAccessControlListHeader) Marshal() ([]byte, error) {
 	return marshalledData, nil
 }
 
-// Describe prints a detailed description of the SystemAccessControlListHeader struct,
-// including its attributes formatted with indentation for clarity.
-//
-// Parameters:
-//   - indent (int): The indentation level for formatting the output. Each level increases
-//     the indentation depth, allowing for a hierarchical display of the SACL's components.
+// DescribeList returns the SystemAccessControlListHeader description as a list
+// of lines at indentation depth 0.
+func (saclheader *SystemAccessControlListHeader) DescribeList() []string {
+	return []string{
+		"<SystemAccessControlListHeader>",
+		fmt.Sprintf(" │ \x1b[93mRevision\x1b[0m : \x1b[96m0x%02x\x1b[0m (\x1b[94m%s\x1b[0m)", saclheader.Revision.Value, saclheader.Revision.String()),
+		fmt.Sprintf(" │ \x1b[93mSbz1\x1b[0m     : \x1b[96m0x%02x\x1b[0m", saclheader.Sbz1),
+		fmt.Sprintf(" │ \x1b[93mAclSize\x1b[0m  : \x1b[96m0x%04x\x1b[0m", saclheader.AclSize),
+		fmt.Sprintf(" │ \x1b[93mAceCount\x1b[0m : \x1b[96m0x%04x\x1b[0m (%d)\x1b[0m", saclheader.AceCount, saclheader.AceCount),
+		fmt.Sprintf(" │ \x1b[93mSbz2\x1b[0m     : \x1b[96m0x%04x\x1b[0m", saclheader.Sbz2),
+		" └─",
+	}
+}
+
+// DescribeWithCallback renders the SystemAccessControlListHeader at the given
+// indentation depth, routing each line to the provided fmt.Printf-like callback.
+func (saclheader *SystemAccessControlListHeader) DescribeWithCallback(indent int, printf describe.Printf) {
+	describe.WithCallback(indent, saclheader.DescribeList(), printf)
+}
+
 func (saclheader *SystemAccessControlListHeader) Describe(indent int) {
-	indentPrompt := strings.Repeat(" │ ", indent)
-	fmt.Printf("%s<SystemAccessControlListHeader>\n", indentPrompt)
-	fmt.Printf("%s │ \x1b[93mRevision\x1b[0m : \x1b[96m0x%02x\x1b[0m (\x1b[94m%s\x1b[0m)\n", indentPrompt, saclheader.Revision.Value, saclheader.Revision.String())
-	fmt.Printf("%s │ \x1b[93mSbz1\x1b[0m     : \x1b[96m0x%02x\x1b[0m\n", indentPrompt, saclheader.Sbz1)
-	fmt.Printf("%s │ \x1b[93mAclSize\x1b[0m  : \x1b[96m0x%04x\x1b[0m\n", indentPrompt, saclheader.AclSize)
-	fmt.Printf("%s │ \x1b[93mAceCount\x1b[0m : \x1b[96m0x%04x\x1b[0m (%d)\x1b[0m\n", indentPrompt, saclheader.AceCount, saclheader.AceCount)
-	fmt.Printf("%s │ \x1b[93mSbz2\x1b[0m     : \x1b[96m0x%04x\x1b[0m\n", indentPrompt, saclheader.Sbz2)
-	fmt.Printf("%s └─\n", indentPrompt)
+	saclheader.DescribeWithCallback(indent, fmt.Printf)
 }

--- a/identity/Identity.go
+++ b/identity/Identity.go
@@ -2,9 +2,9 @@ package identity
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/TheManticoreProject/winacl/sid"
+	"github.com/TheManticoreProject/winacl/utils/describe"
 )
 
 // Identity represents a user identity, including its name and associated Security Identifier (SID).
@@ -70,15 +70,24 @@ func (identity *Identity) Marshal() ([]byte, error) {
 // Parameters:
 //   - indent (int): The indentation level for formatting the output. Each level increases
 //     the indentation depth, allowing for a hierarchical display of the Identity's components.
+//
+// DescribeList returns the Identity description as a list of lines at
+// indentation depth 0.
+func (identity *Identity) DescribeList() []string {
+	return []string{
+		"<Identity>",
+		fmt.Sprintf(" │ \x1b[93mSID\x1b[0m  : \x1b[96m%s\x1b[0m", identity.SID.ToString()),
+		fmt.Sprintf(" │ \x1b[93mName\x1b[0m : '\x1b[94m%s\x1b[0m'", identity.Name),
+		" └─",
+	}
+}
+
+// DescribeWithCallback renders the Identity at the given indentation depth,
+// routing each line to the provided fmt.Printf-like callback.
+func (identity *Identity) DescribeWithCallback(indent int, printf describe.Printf) {
+	describe.WithCallback(indent, identity.DescribeList(), printf)
+}
+
 func (identity *Identity) Describe(indent int) {
-	indentPrompt := strings.Repeat(" │ ", indent)
-
-	fmt.Printf("%s<Identity>\n", indentPrompt)
-
-	fmt.Printf("%s │ \x1b[93mSID\x1b[0m  : \x1b[96m%s\x1b[0m\n", indentPrompt, identity.SID.ToString())
-	//identity.SID.Describe(indent + 1)
-
-	fmt.Printf("%s │ \x1b[93mName\x1b[0m : '\x1b[94m%s\x1b[0m'\n", indentPrompt, identity.Name)
-
-	fmt.Printf("%s └─\n", indentPrompt)
+	identity.DescribeWithCallback(indent, fmt.Printf)
 }

--- a/object/AccessControlObjectType.go
+++ b/object/AccessControlObjectType.go
@@ -2,9 +2,9 @@ package object
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/TheManticoreProject/winacl/object/flags"
+	"github.com/TheManticoreProject/winacl/utils/describe"
 )
 
 // AccessControlObjectType represents the access control object type.
@@ -101,26 +101,49 @@ func (aco *AccessControlObjectType) Marshal() ([]byte, error) {
 //
 // Attributes:
 //   - indent (int): The indentation level for the output.
-func (aco *AccessControlObjectType) Describe(indent int) {
-	indentPrompt := strings.Repeat(" │ ", indent)
-
-	fmt.Printf("%s<AccessControlObjectType>\n", indentPrompt)
+//
+// DescribeList returns the AccessControlObjectType description as a list of
+// lines at indentation depth 0.
+func (aco *AccessControlObjectType) DescribeList() []string {
+	lines := []string{"<AccessControlObjectType>"}
 
 	if aco.Flags.Value == (flags.ACCESS_CONTROL_OBJECT_TYPE_FLAG_INHERITED_OBJECT_TYPE_PRESENT | flags.ACCESS_CONTROL_OBJECT_TYPE_FLAG_OBJECT_TYPE_PRESENT) {
-		fmt.Printf("%s │ \x1b[93mFlags\x1b[0m               : \x1b[96m0x%08x\x1b[0m (\x1b[94m%s\x1b[0m)\n", indentPrompt, aco.Flags.Value, aco.Flags.Name)
-		fmt.Printf("%s │ \x1b[93mObjectType\x1b[0m          : \x1b[96m%s\x1b[0m (\x1b[94m%s\x1b[0m)\n", indentPrompt, aco.ObjectType.GUID.ToFormatD(), aco.ObjectType.GUID.LookupName())
-		fmt.Printf("%s │ \x1b[93mInheritedObjectType\x1b[0m : \x1b[96m%s\x1b[0m (\x1b[94m%s\x1b[0m)\n", indentPrompt, aco.InheritedObjectType.GUID.ToFormatD(), aco.InheritedObjectType.GUID.LookupName())
+		lines = append(lines,
+			fmt.Sprintf(" │ \x1b[93mFlags\x1b[0m               : \x1b[96m0x%08x\x1b[0m (\x1b[94m%s\x1b[0m)", aco.Flags.Value, aco.Flags.Name),
+			fmt.Sprintf(" │ \x1b[93mObjectType\x1b[0m          : \x1b[96m%s\x1b[0m (\x1b[94m%s\x1b[0m)", aco.ObjectType.GUID.ToFormatD(), aco.ObjectType.GUID.LookupName()),
+			fmt.Sprintf(" │ \x1b[93mInheritedObjectType\x1b[0m : \x1b[96m%s\x1b[0m (\x1b[94m%s\x1b[0m)", aco.InheritedObjectType.GUID.ToFormatD(), aco.InheritedObjectType.GUID.LookupName()),
+		)
 	} else if aco.Flags.Value == flags.ACCESS_CONTROL_OBJECT_TYPE_FLAG_INHERITED_OBJECT_TYPE_PRESENT {
-		fmt.Printf("%s │ \x1b[93mFlags\x1b[0m               : \x1b[96m0x%08x\x1b[0m (\x1b[94m%s\x1b[0m)\n", indentPrompt, aco.Flags.Value, aco.Flags.Name)
-		fmt.Printf("%s │ \x1b[93mInheritedObjectType\x1b[0m : \x1b[96m%s\x1b[0m (\x1b[94m%s\x1b[0m)\n", indentPrompt, aco.InheritedObjectType.GUID.ToFormatD(), aco.InheritedObjectType.GUID.LookupName())
+		lines = append(lines,
+			fmt.Sprintf(" │ \x1b[93mFlags\x1b[0m               : \x1b[96m0x%08x\x1b[0m (\x1b[94m%s\x1b[0m)", aco.Flags.Value, aco.Flags.Name),
+			fmt.Sprintf(" │ \x1b[93mInheritedObjectType\x1b[0m : \x1b[96m%s\x1b[0m (\x1b[94m%s\x1b[0m)", aco.InheritedObjectType.GUID.ToFormatD(), aco.InheritedObjectType.GUID.LookupName()),
+		)
 	} else if aco.Flags.Value == flags.ACCESS_CONTROL_OBJECT_TYPE_FLAG_OBJECT_TYPE_PRESENT {
-		fmt.Printf("%s │ \x1b[93mFlags\x1b[0m      : \x1b[96m0x%08x\x1b[0m (\x1b[94m%s\x1b[0m)\n", indentPrompt, aco.Flags.Value, aco.Flags.Name)
-		fmt.Printf("%s │ \x1b[93mObjectType\x1b[0m : \x1b[96m%s\x1b[0m (\x1b[94m%s\x1b[0m)\n", indentPrompt, aco.ObjectType.GUID.ToFormatD(), aco.ObjectType.GUID.LookupName())
+		lines = append(lines,
+			fmt.Sprintf(" │ \x1b[93mFlags\x1b[0m      : \x1b[96m0x%08x\x1b[0m (\x1b[94m%s\x1b[0m)", aco.Flags.Value, aco.Flags.Name),
+			fmt.Sprintf(" │ \x1b[93mObjectType\x1b[0m : \x1b[96m%s\x1b[0m (\x1b[94m%s\x1b[0m)", aco.ObjectType.GUID.ToFormatD(), aco.ObjectType.GUID.LookupName()),
+		)
 	} else if aco.Flags.Value == flags.ACCESS_CONTROL_OBJECT_TYPE_FLAG_NONE {
-		fmt.Printf("%s │ \x1b[93mFlags\x1b[0m : \x1b[96m0x%08x\x1b[0m (\x1b[94m%s\x1b[0m)\n", indentPrompt, aco.Flags.Value, aco.Flags.Name)
+		lines = append(lines,
+			fmt.Sprintf(" │ \x1b[93mFlags\x1b[0m : \x1b[96m0x%08x\x1b[0m (\x1b[94m%s\x1b[0m)", aco.Flags.Value, aco.Flags.Name),
+		)
 	} else {
-		fmt.Printf("%s │ \x1b[93mFlags\x1b[0m : \x1b[96m0x%08x\x1b[0m (\x1b[94m%s\x1b[0m)\n", indentPrompt, aco.Flags.Value, aco.Flags.Name)
+		lines = append(lines,
+			fmt.Sprintf(" │ \x1b[93mFlags\x1b[0m : \x1b[96m0x%08x\x1b[0m (\x1b[94m%s\x1b[0m)", aco.Flags.Value, aco.Flags.Name),
+		)
 	}
 
-	fmt.Printf("%s └─\n", indentPrompt)
+	lines = append(lines, " └─")
+
+	return lines
+}
+
+// DescribeWithCallback renders the AccessControlObjectType at the given
+// indentation depth, routing each line to the provided fmt.Printf-like callback.
+func (aco *AccessControlObjectType) DescribeWithCallback(indent int, printf describe.Printf) {
+	describe.WithCallback(indent, aco.DescribeList(), printf)
+}
+
+func (aco *AccessControlObjectType) Describe(indent int) {
+	aco.DescribeWithCallback(indent, fmt.Printf)
 }

--- a/object/InheritedObjectType.go
+++ b/object/InheritedObjectType.go
@@ -2,9 +2,9 @@ package object
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/TheManticoreProject/winacl/guid"
+	"github.com/TheManticoreProject/winacl/utils/describe"
 )
 
 // InheritedObjectType represents a type of object that inherits
@@ -60,9 +60,22 @@ func (inheritedObjType *InheritedObjectType) Marshal() ([]byte, error) {
 // Describe prints a formatted representation of the InheritedObjectType instance,
 // including its GUID, to the standard output. The output is indented
 // based on the provided indent level for better readability.
+// DescribeList returns the InheritedObjectType description as a list of lines at
+// indentation depth 0.
+func (inheritedObjType *InheritedObjectType) DescribeList() []string {
+	return []string{
+		"<InheritedObjectType>",
+		fmt.Sprintf(" │ \x1b[93mGUID\x1b[0m : \x1b[96m%s\x1b[0m", inheritedObjType.GUID.ToFormatD()),
+		" └─",
+	}
+}
+
+// DescribeWithCallback renders the InheritedObjectType at the given indentation
+// depth, routing each line to the provided fmt.Printf-like callback.
+func (inheritedObjType *InheritedObjectType) DescribeWithCallback(indent int, printf describe.Printf) {
+	describe.WithCallback(indent, inheritedObjType.DescribeList(), printf)
+}
+
 func (inheritedObjType *InheritedObjectType) Describe(indent int) {
-	indentPrompt := strings.Repeat(" │ ", indent)
-	fmt.Printf("%s<InheritedObjectType>\n", indentPrompt)
-	fmt.Printf("%s │ \x1b[93mGUID\x1b[0m : \x1b[96m%s\x1b[0m\n", indentPrompt, inheritedObjType.GUID.ToFormatD())
-	fmt.Printf("%s └─\n", indentPrompt)
+	inheritedObjType.DescribeWithCallback(indent, fmt.Printf)
 }

--- a/object/ObjectType.go
+++ b/object/ObjectType.go
@@ -2,9 +2,9 @@ package object
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/TheManticoreProject/winacl/guid"
+	"github.com/TheManticoreProject/winacl/utils/describe"
 )
 
 // ObjectType represents a type of object with an associated GUID.
@@ -55,9 +55,22 @@ func (objType *ObjectType) Marshal() ([]byte, error) {
 // Describe prints a formatted representation of the ObjectType instance,
 // including its GUID, to the standard output. The output is indented
 // based on the provided indent level for better readability.
+// DescribeList returns the ObjectType description as a list of lines at
+// indentation depth 0.
+func (objType *ObjectType) DescribeList() []string {
+	return []string{
+		"<ObjectType>",
+		fmt.Sprintf(" │ \x1b[93mGUID\x1b[0m : \x1b[96m%s\x1b[0m", objType.GUID.ToFormatD()),
+		" └─",
+	}
+}
+
+// DescribeWithCallback renders the ObjectType at the given indentation depth,
+// routing each line to the provided fmt.Printf-like callback.
+func (objType *ObjectType) DescribeWithCallback(indent int, printf describe.Printf) {
+	describe.WithCallback(indent, objType.DescribeList(), printf)
+}
+
 func (objType *ObjectType) Describe(indent int) {
-	indentPrompt := strings.Repeat(" │ ", indent)
-	fmt.Printf("%s<ObjectType>\n", indentPrompt)
-	fmt.Printf("%s │ \x1b[93mGUID\x1b[0m : \x1b[96m%s\x1b[0m\n", indentPrompt, objType.GUID.ToFormatD())
-	fmt.Printf("%s └─\n", indentPrompt)
+	objType.DescribeWithCallback(indent, fmt.Printf)
 }

--- a/securitydescriptor/NtSecurityDescriptor.go
+++ b/securitydescriptor/NtSecurityDescriptor.go
@@ -2,12 +2,12 @@ package securitydescriptor
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/TheManticoreProject/winacl/acl"
 	"github.com/TheManticoreProject/winacl/identity"
 	"github.com/TheManticoreProject/winacl/securitydescriptor/control"
 	"github.com/TheManticoreProject/winacl/securitydescriptor/header"
+	"github.com/TheManticoreProject/winacl/utils/describe"
 )
 
 // ntSecurityDescriptorHeaderSize is the fixed size, in bytes, of the security
@@ -235,80 +235,71 @@ func (ntsd *NtSecurityDescriptor) Marshal() ([]byte, error) {
 	return marshalledData, nil
 }
 
+// DescribeList returns the NtSecurityDescriptor description as a list of lines
+// at indentation depth 0, nesting the header, owner, group and ACLs one level
+// deeper. The DACL/SACL are ordered to match their on-the-wire offsets.
+func (ntsd *NtSecurityDescriptor) DescribeList() []string {
+	lines := []string{"<NTSecurityDescriptor>"}
+
+	lines = append(lines, describe.Nest(ntsd.Header.DescribeList())...)
+
+	if ntsd.Owner != nil {
+		owner := []string{"<Owner>"}
+		owner = append(owner, describe.Nest(ntsd.Owner.DescribeList())...)
+		owner = append(owner, " └─")
+		lines = append(lines, describe.Nest(owner)...)
+	}
+
+	if ntsd.Group != nil {
+		group := []string{"<Group>"}
+		group = append(group, describe.Nest(ntsd.Group.DescribeList())...)
+		group = append(group, " └─")
+		lines = append(lines, describe.Nest(group)...)
+	}
+
+	describeDACL := func() []string {
+		if ntsd.DACL != nil {
+			if len(ntsd.DACL.Entries) > 0 {
+				return describe.Nest(ntsd.DACL.DescribeList())
+			}
+			return describe.Nest([]string{"<DiscretionaryAccessControlList is \x1b[93mempty\x1b[0m>", " └─"})
+		}
+		return describe.Nest([]string{"<DiscretionaryAccessControlList is \x1b[91mnot present\x1b[0m>", " └─"})
+	}
+
+	describeSACL := func() []string {
+		if ntsd.SACL != nil {
+			if len(ntsd.SACL.Entries) > 0 {
+				return describe.Nest(ntsd.SACL.DescribeList())
+			}
+			return describe.Nest([]string{"<SystemAccessControlList is \x1b[93mempty\x1b[0m>", " └─"})
+		}
+		return describe.Nest([]string{"<SystemAccessControlList is \x1b[91mnot present\x1b[0m>", " └─"})
+	}
+
+	if ntsd.Header.OffsetSacl > ntsd.Header.OffsetDacl {
+		lines = append(lines, describeDACL()...)
+		lines = append(lines, describeSACL()...)
+	} else {
+		lines = append(lines, describeSACL()...)
+		lines = append(lines, describeDACL()...)
+	}
+
+	lines = append(lines, " └─")
+
+	return lines
+}
+
+// DescribeWithCallback renders the NtSecurityDescriptor at the given
+// indentation depth, routing each line to the provided fmt.Printf-like callback.
+func (ntsd *NtSecurityDescriptor) DescribeWithCallback(indent int, printf describe.Printf) {
+	describe.WithCallback(indent, ntsd.DescribeList(), printf)
+}
+
 // Describe prints the NtSecurityDescriptor in a human-readable format.
 //
 // Parameters:
 //   - indent (int): The indentation level for the output.
 func (ntsd *NtSecurityDescriptor) Describe(indent int) {
-	fmt.Println("<NTSecurityDescriptor>")
-
-	ntsd.Header.Describe(indent + 1)
-
-	if ntsd.Owner != nil {
-		fmt.Printf("%s<Owner>\n", strings.Repeat(" │ ", indent+1))
-		ntsd.Owner.Describe(indent + 2)
-		fmt.Printf("%s └─\n", strings.Repeat(" │ ", indent+1))
-	}
-
-	if ntsd.Group != nil {
-		fmt.Printf("%s<Group>\n", strings.Repeat(" │ ", indent+1))
-		ntsd.Group.Describe(indent + 2)
-		fmt.Printf("%s └─\n", strings.Repeat(" │ ", indent+1))
-	}
-
-	if ntsd.Header.OffsetSacl > ntsd.Header.OffsetDacl {
-		// Print DACL
-		if ntsd.DACL != nil {
-			if len(ntsd.DACL.Entries) > 0 {
-				ntsd.DACL.Describe(indent + 1)
-			} else {
-				fmt.Printf("%s<DiscretionaryAccessControlList is \x1b[93mempty\x1b[0m>\n", strings.Repeat(" │ ", indent+1))
-				fmt.Printf("%s └─\n", strings.Repeat(" │ ", indent+1))
-			}
-		} else {
-			fmt.Printf("%s<DiscretionaryAccessControlList is \x1b[91mnot present\x1b[0m>\n", strings.Repeat(" │ ", indent+1))
-			fmt.Printf("%s └─\n", strings.Repeat(" │ ", indent+1))
-		}
-
-		// Print SACL
-		if ntsd.SACL != nil {
-			if len(ntsd.SACL.Entries) > 0 {
-				ntsd.SACL.Describe(indent + 1)
-			} else {
-				fmt.Printf("%s<SystemAccessControlList is \x1b[93mempty\x1b[0m>\n", strings.Repeat(" │ ", indent+1))
-				fmt.Printf("%s └─\n", strings.Repeat(" │ ", indent+1))
-			}
-		} else {
-			fmt.Printf("%s<SystemAccessControlList is \x1b[91mnot present\x1b[0m>\n", strings.Repeat(" │ ", indent+1))
-			fmt.Printf("%s └─\n", strings.Repeat(" │ ", indent+1))
-		}
-	} else {
-		// Print SACL
-		if ntsd.SACL != nil {
-			if len(ntsd.SACL.Entries) > 0 {
-				ntsd.SACL.Describe(indent + 1)
-			} else {
-				fmt.Printf("%s<SystemAccessControlList is \x1b[93mempty\x1b[0m>\n", strings.Repeat(" │ ", indent+1))
-				fmt.Printf("%s └─\n", strings.Repeat(" │ ", indent+1))
-			}
-		} else {
-			fmt.Printf("%s<SystemAccessControlList is \x1b[91mnot present\x1b[0m>\n", strings.Repeat(" │ ", indent+1))
-			fmt.Printf("%s └─\n", strings.Repeat(" │ ", indent+1))
-		}
-
-		// Print DACL
-		if ntsd.DACL != nil {
-			if len(ntsd.DACL.Entries) > 0 {
-				ntsd.DACL.Describe(indent + 1)
-			} else {
-				fmt.Printf("%s<DiscretionaryAccessControlList is \x1b[93mempty\x1b[0m>\n", strings.Repeat(" │ ", indent+1))
-				fmt.Printf("%s └─\n", strings.Repeat(" │ ", indent+1))
-			}
-		} else {
-			fmt.Printf("%s<DiscretionaryAccessControlList is \x1b[91mnot present\x1b[0m>\n", strings.Repeat(" │ ", indent+1))
-			fmt.Printf("%s └─\n", strings.Repeat(" │ ", indent+1))
-		}
-	}
-
-	fmt.Println(" └─")
+	ntsd.DescribeWithCallback(indent, fmt.Printf)
 }

--- a/securitydescriptor/NtSecurityDescriptor_describe_test.go
+++ b/securitydescriptor/NtSecurityDescriptor_describe_test.go
@@ -1,0 +1,92 @@
+package securitydescriptor
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/TheManticoreProject/winacl/utils/describe"
+)
+
+// captureStdout runs f and returns everything it wrote to os.Stdout.
+func captureStdout(t *testing.T, f func()) string {
+	t.Helper()
+	orig := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+	done := make(chan string, 1)
+	go func() {
+		b, _ := io.ReadAll(r)
+		done <- string(b)
+	}()
+	f()
+	w.Close()
+	os.Stdout = orig
+	return <-done
+}
+
+// sampleNTSD builds a security descriptor with an owner, group and a populated
+// DACL so the describe tree exercises nesting through every layer.
+func sampleNTSD(t *testing.T) *NtSecurityDescriptor {
+	t.Helper()
+	const sddl = `O:BAG:BAD:(A;;GA;;;S-1-1-0)(D;;GR;;;S-1-5-32-545)`
+	ntsd := &NtSecurityDescriptor{}
+	if _, err := ntsd.FromSDDLString(sddl); err != nil {
+		t.Fatalf("FromSDDLString error = %v", err)
+	}
+	return ntsd
+}
+
+// TestDescribeLayeringConsistency verifies that Describe, DescribeWithCallback
+// and DescribeList are three views of the same content: Describe(0) prints
+// exactly the DescribeList lines each terminated by a newline, and
+// DescribeWithCallback routes the same lines to a custom sink.
+func TestDescribeLayeringConsistency(t *testing.T) {
+	ntsd := sampleNTSD(t)
+
+	lines := ntsd.DescribeList()
+	if len(lines) == 0 {
+		t.Fatal("DescribeList returned no lines")
+	}
+
+	// Describe(0) must equal every line joined with newlines (indent 0 adds no
+	// prefix), with a trailing newline after the last line.
+	want := strings.Join(lines, "\n") + "\n"
+	got := captureStdout(t, func() { ntsd.Describe(0) })
+	if got != want {
+		t.Fatalf("Describe(0) output does not match DescribeList:\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+
+	// DescribeWithCallback at indent 0 must deliver the same lines.
+	var collected []string
+	ntsd.DescribeWithCallback(0, func(format string, a ...any) (int, error) {
+		collected = append(collected, strings.TrimSuffix(fmt.Sprintf(format, a...), "\n"))
+		return 0, nil
+	})
+	if strings.Join(collected, "\n") != strings.Join(lines, "\n") {
+		t.Fatalf("DescribeWithCallback lines differ from DescribeList:\n%v", collected)
+	}
+}
+
+// TestDescribeIndentPrefix verifies that a non-zero indent prefixes every line
+// with the expected number of indentation units.
+func TestDescribeIndentPrefix(t *testing.T) {
+	ntsd := sampleNTSD(t)
+	lines := ntsd.DescribeList()
+
+	out := captureStdout(t, func() { ntsd.Describe(2) })
+	prefix := strings.Repeat(describe.Unit, 2) // two indentation units
+	for _, got := range strings.Split(strings.TrimRight(out, "\n"), "\n") {
+		if !strings.HasPrefix(got, prefix) {
+			t.Fatalf("line missing indent prefix %q: %q", prefix, got)
+		}
+	}
+	if n := len(strings.Split(strings.TrimRight(out, "\n"), "\n")); n != len(lines) {
+		t.Fatalf("Describe(2) emitted %d lines, DescribeList has %d", n, len(lines))
+	}
+}

--- a/securitydescriptor/header/NtSecurityDescriptorHeader.go
+++ b/securitydescriptor/header/NtSecurityDescriptorHeader.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 
 	"github.com/TheManticoreProject/winacl/securitydescriptor/control"
+	"github.com/TheManticoreProject/winacl/utils/describe"
 )
 
 // NtSecurityDescriptorHeader represents the header of a NT Security Descriptor,
@@ -121,15 +122,29 @@ func (ntsdh *NtSecurityDescriptorHeader) Marshal() ([]byte, error) {
 // Parameters:
 //   - indent (int): The indentation level for formatting the output. Each level increases
 //     the indentation depth, allowing for a hierarchical display of the header's components.
+//
+// DescribeList returns the NtSecurityDescriptorHeader description as a list of
+// lines at indentation depth 0.
+func (ntsd *NtSecurityDescriptorHeader) DescribeList() []string {
+	return []string{
+		"<NtSecurityDescriptorHeader>",
+		fmt.Sprintf(" │ \x1b[93mRevision\x1b[0m    : \x1b[96m0x%02x\x1b[0m", ntsd.Revision),
+		fmt.Sprintf(" │ \x1b[93mSbz1\x1b[0m        : \x1b[96m0x%02x\x1b[0m", ntsd.Sbz1),
+		fmt.Sprintf(" │ \x1b[93mControl\x1b[0m     : \x1b[96m0x%04x\x1b[0m (\x1b[94m%s\x1b[0m)", ntsd.Control.RawValue, strings.Join(ntsd.Control.Flags, "|")),
+		fmt.Sprintf(" │ \x1b[93mOffsetOwner\x1b[0m : \x1b[96m0x%08x\x1b[0m (\x1b[94m%d\x1b[0m)", ntsd.OffsetOwner, ntsd.OffsetOwner),
+		fmt.Sprintf(" │ \x1b[93mOffsetGroup\x1b[0m : \x1b[96m0x%08x\x1b[0m (\x1b[94m%d\x1b[0m)", ntsd.OffsetGroup, ntsd.OffsetGroup),
+		fmt.Sprintf(" │ \x1b[93mOffsetSacl\x1b[0m  : \x1b[96m0x%08x\x1b[0m (\x1b[94m%d\x1b[0m)", ntsd.OffsetSacl, ntsd.OffsetSacl),
+		fmt.Sprintf(" │ \x1b[93mOffsetDacl\x1b[0m  : \x1b[96m0x%08x\x1b[0m (\x1b[94m%d\x1b[0m)", ntsd.OffsetDacl, ntsd.OffsetDacl),
+		" └─",
+	}
+}
+
+// DescribeWithCallback renders the NtSecurityDescriptorHeader at the given
+// indentation depth, routing each line to the provided fmt.Printf-like callback.
+func (ntsd *NtSecurityDescriptorHeader) DescribeWithCallback(indent int, printf describe.Printf) {
+	describe.WithCallback(indent, ntsd.DescribeList(), printf)
+}
+
 func (ntsd *NtSecurityDescriptorHeader) Describe(indent int) {
-	indentPrompt := strings.Repeat(" │ ", indent)
-	fmt.Printf("%s<NtSecurityDescriptorHeader>\n", indentPrompt)
-	fmt.Printf("%s │ \x1b[93mRevision\x1b[0m    : \x1b[96m0x%02x\x1b[0m\n", indentPrompt, ntsd.Revision)
-	fmt.Printf("%s │ \x1b[93mSbz1\x1b[0m        : \x1b[96m0x%02x\x1b[0m\n", indentPrompt, ntsd.Sbz1)
-	fmt.Printf("%s │ \x1b[93mControl\x1b[0m     : \x1b[96m0x%04x\x1b[0m (\x1b[94m%s\x1b[0m)\n", indentPrompt, ntsd.Control.RawValue, strings.Join(ntsd.Control.Flags, "|"))
-	fmt.Printf("%s │ \x1b[93mOffsetOwner\x1b[0m : \x1b[96m0x%08x\x1b[0m (\x1b[94m%d\x1b[0m)\n", indentPrompt, ntsd.OffsetOwner, ntsd.OffsetOwner)
-	fmt.Printf("%s │ \x1b[93mOffsetGroup\x1b[0m : \x1b[96m0x%08x\x1b[0m (\x1b[94m%d\x1b[0m)\n", indentPrompt, ntsd.OffsetGroup, ntsd.OffsetGroup)
-	fmt.Printf("%s │ \x1b[93mOffsetSacl\x1b[0m  : \x1b[96m0x%08x\x1b[0m (\x1b[94m%d\x1b[0m)\n", indentPrompt, ntsd.OffsetSacl, ntsd.OffsetSacl)
-	fmt.Printf("%s │ \x1b[93mOffsetDacl\x1b[0m  : \x1b[96m0x%08x\x1b[0m (\x1b[94m%d\x1b[0m)\n", indentPrompt, ntsd.OffsetDacl, ntsd.OffsetDacl)
-	fmt.Printf("%s └─\n", indentPrompt)
+	ntsd.DescribeWithCallback(indent, fmt.Printf)
 }

--- a/sid/SecurityIdentifier.go
+++ b/sid/SecurityIdentifier.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/TheManticoreProject/winacl/sid/authority"
+	"github.com/TheManticoreProject/winacl/utils/describe"
 )
 
 const (
@@ -500,24 +501,41 @@ func (sid *SID) String() string {
 // Parameters:
 //   - indent (int): The indentation level for formatting the output. Each level increases
 //     the indentation depth, allowing for a hierarchical display of the SID's components.
-func (sid *SID) Describe(indent int) {
-	indentPrompt := strings.Repeat(" │ ", indent)
-
-	fmt.Printf("%s<SID '%s'>\n", indentPrompt, sid.ToString())
-	fmt.Printf("%s │ \x1b[93mRevisionLevel\x1b[0m        : \x1b[96m0x%02x\x1b[0m\n", indentPrompt, sid.RevisionLevel)
-	fmt.Printf("%s │ \x1b[93mSubAuthorityCount\x1b[0m    : \x1b[96m0x%02x\x1b[0m\n", indentPrompt, sid.SubAuthorityCount)
-	fmt.Printf("%s │ \x1b[93mIdentifierAuthority\x1b[0m  : \x1b[96m0x%012x\x1b[0m (\x1b[94m%s\x1b[0m)\n", indentPrompt, sid.IdentifierAuthority, sid.IdentifierAuthority.String())
-
-	if sid.SubAuthorityCount != 0 {
-		fmt.Printf("%s │ \x1b[93mSubAuthorities (%03d)\x1b[0m :\n", indentPrompt, sid.SubAuthorityCount)
-		for index, subauthority := range sid.SubAuthorities {
-			fmt.Printf("%s │ \x1b[93mSubAuthority %02d\x1b[0m   : \x1b[96m0x%08x\x1b[0m (\x1b[94m%d\x1b[0m)\n", strings.Repeat(" │ ", indent+1), index, subauthority, subauthority)
-		}
-		fmt.Printf("%s └─\n", strings.Repeat(" │ ", indent+1))
-	} else {
-		fmt.Printf("%s │ \x1b[93mSubAuthorities (0)\x1b[0m   : Empty\n", indentPrompt)
+//
+// DescribeList returns the SID description as a list of lines at indentation
+// depth 0.
+func (sid *SID) DescribeList() []string {
+	lines := []string{
+		fmt.Sprintf("<SID '%s'>", sid.ToString()),
+		fmt.Sprintf(" │ \x1b[93mRevisionLevel\x1b[0m        : \x1b[96m0x%02x\x1b[0m", sid.RevisionLevel),
+		fmt.Sprintf(" │ \x1b[93mSubAuthorityCount\x1b[0m    : \x1b[96m0x%02x\x1b[0m", sid.SubAuthorityCount),
+		fmt.Sprintf(" │ \x1b[93mIdentifierAuthority\x1b[0m  : \x1b[96m0x%012x\x1b[0m (\x1b[94m%s\x1b[0m)", sid.IdentifierAuthority, sid.IdentifierAuthority.String()),
 	}
 
-	fmt.Printf("%s │ \x1b[93mRelativeIdentifier\x1b[0m   : \x1b[96m0x%08x\x1b[0m (\x1b[94m%d\x1b[0m)\n", indentPrompt, sid.RelativeIdentifier, sid.RelativeIdentifier)
-	fmt.Printf("%s └─\n", indentPrompt)
+	if sid.SubAuthorityCount != 0 {
+		lines = append(lines, fmt.Sprintf(" │ \x1b[93mSubAuthorities (%03d)\x1b[0m :", sid.SubAuthorityCount))
+		for index, subauthority := range sid.SubAuthorities {
+			lines = append(lines, describe.Unit+fmt.Sprintf(" │ \x1b[93mSubAuthority %02d\x1b[0m   : \x1b[96m0x%08x\x1b[0m (\x1b[94m%d\x1b[0m)", index, subauthority, subauthority))
+		}
+		lines = append(lines, describe.Unit+" └─")
+	} else {
+		lines = append(lines, " │ \x1b[93mSubAuthorities (0)\x1b[0m   : Empty")
+	}
+
+	lines = append(lines,
+		fmt.Sprintf(" │ \x1b[93mRelativeIdentifier\x1b[0m   : \x1b[96m0x%08x\x1b[0m (\x1b[94m%d\x1b[0m)", sid.RelativeIdentifier, sid.RelativeIdentifier),
+		" └─",
+	)
+
+	return lines
+}
+
+// DescribeWithCallback renders the SID at the given indentation depth, routing
+// each line to the provided fmt.Printf-like callback.
+func (sid *SID) DescribeWithCallback(indent int, printf describe.Printf) {
+	describe.WithCallback(indent, sid.DescribeList(), printf)
+}
+
+func (sid *SID) Describe(indent int) {
+	sid.DescribeWithCallback(indent, fmt.Printf)
 }

--- a/utils/describe/describe.go
+++ b/utils/describe/describe.go
@@ -1,0 +1,45 @@
+// Package describe provides the shared rendering primitives used by the
+// Describe / DescribeList / DescribeWithCallback trio implemented on every
+// winacl structure.
+//
+// Each structure exposes its output as a flat list of lines at indentation
+// depth 0 via DescribeList(). Rendering (adding indentation and choosing where
+// the text goes) is layered on top:
+//
+//	DescribeList()                -> []string, the lines at indent 0
+//	DescribeWithCallback(indent,  -> prepends indent levels and routes each line
+//	                     printf)      to a fmt.Printf-like callback
+//	Describe(indent)              -> DescribeWithCallback(indent, fmt.Printf)
+//
+// A parent structure composes its own list from its children's by nesting each
+// child's DescribeList() one level deeper with Nest.
+package describe
+
+import "strings"
+
+// Unit is one level of indentation in the Describe tree output.
+const Unit = " │ "
+
+// Printf is the signature of a fmt.Printf-like sink. fmt.Printf satisfies it
+// directly, as does any wrapper around fmt.Fprintf or a structured logger.
+type Printf = func(format string, a ...any) (int, error)
+
+// Nest prefixes each of the given lines with one indentation Unit. It is used to
+// compose a parent's DescribeList from its children's DescribeList output.
+func Nest(lines []string) []string {
+	nested := make([]string, len(lines))
+	for i, line := range lines {
+		nested[i] = Unit + line
+	}
+	return nested
+}
+
+// WithCallback renders lines at the given indentation depth: it prepends indent
+// copies of Unit to each line and routes the result (with a trailing newline) to
+// printf.
+func WithCallback(indent int, lines []string, printf Printf) {
+	prefix := strings.Repeat(Unit, indent)
+	for _, line := range lines {
+		printf("%s%s\n", prefix, line)
+	}
+}

--- a/utils/describe/describe_test.go
+++ b/utils/describe/describe_test.go
@@ -1,0 +1,47 @@
+package describe_test
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/TheManticoreProject/winacl/utils/describe"
+)
+
+// TestNest prefixes each line with exactly one indentation unit.
+func TestNest(t *testing.T) {
+	in := []string{"<A>", " │ x : 1", " └─"}
+	got := describe.Nest(in)
+
+	if len(got) != len(in) {
+		t.Fatalf("Nest changed line count: got %d, want %d", len(got), len(in))
+	}
+	for i := range got {
+		want := describe.Unit + in[i]
+		if got[i] != want {
+			t.Fatalf("Nest[%d] = %q, want %q", i, got[i], want)
+		}
+	}
+
+	// Nest must not mutate its input.
+	if in[0] != "<A>" {
+		t.Fatalf("Nest mutated its input: %q", in[0])
+	}
+}
+
+// TestWithCallback prepends indent levels and routes each line to the callback
+// with a trailing newline.
+func TestWithCallback(t *testing.T) {
+	lines := []string{"<A>", " └─"}
+	var got []string
+	describe.WithCallback(2, lines, func(format string, a ...any) (int, error) {
+		got = append(got, strings.TrimSuffix(fmt.Sprintf(format, a...), "\n"))
+		return 0, nil
+	})
+
+	prefix := strings.Repeat(describe.Unit, 2)
+	want := []string{prefix + "<A>", prefix + " └─"}
+	if strings.Join(got, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("WithCallback produced:\n%v\nwant:\n%v", got, want)
+	}
+}


### PR DESCRIPTION
### Linked Issue
`Closes #125`

### Root Cause
Every structure's `Describe(indent int)` built its lines with an inline `strings.Repeat(" │ ", indent)` prefix and wrote them straight to stdout with `fmt.Printf`. Rendered content and rendering (indentation + output sink) were entangled, and composite types propagated the coupling by calling `child.Describe(indent+1)`. There was no way to obtain a description as data or route it to a non-stdout sink.

### Fix Description
Introduce a shared `utils/describe` package and split every `Describe` into three layers:

- `DescribeList() []string` — the content at indentation depth 0 (source of truth). Composites build theirs by nesting each child's `DescribeList` one level deeper via `describe.Nest`, replacing the old `child.Describe(indent+1)` calls.
- `DescribeWithCallback(indent int, printf func(string, ...any) (int, error))` — prepends `indent` indentation units to each line and routes it to a `fmt.Printf`-like callback.
- `Describe(indent int)` — unchanged signature and behavior; delegates to `DescribeWithCallback(indent, fmt.Printf)`.

`utils/describe` provides `Unit`, `Nest`, `WithCallback`, and the `Printf` type alias. The callback is `fmt.Printf`-shaped so `fmt.Printf` can be passed directly, and any logger / `fmt.Fprintf` wrapper works as a sink.

Converted all 15 implementations: `ace/mask`, `ace/header`, `ace/applicationdata`, `ace.AccessControlEntry`, `identity`, `sid`, `object` (×3), `acl` (×4), `securitydescriptor/header`, `securitydescriptor.NtSecurityDescriptor`.

### How Verified
- `go build ./...`, `go vet ./...`, `gofmt -l` — all clean.
- `go test ./...` — all packages pass, including existing describe/SDDL/round-trip suites.
- New consistency test asserts `Describe(0)` output equals `DescribeList()` joined with newlines, and that `DescribeWithCallback` delivers the same lines; a second test checks indent prefixing at `indent=2`.

### Test Coverage
**Added:** `utils/describe/describe_test.go` (`TestNest`, `TestWithCallback`); `securitydescriptor/NtSecurityDescriptor_describe_test.go` (`TestDescribeLayeringConsistency`, `TestDescribeIndentPrefix`).
**Existing:** `ace` and `securitydescriptor` describe tests continue to pass unchanged, confirming byte-identical output at `indent=0`.

### Scope of Change
- **Files changed:** `utils/describe/describe.go` (new), `utils/describe/describe_test.go` (new), `securitydescriptor/NtSecurityDescriptor_describe_test.go` (new), plus the 15 structure files listed above.
- **Submodule pointer updated:** no
- **Behavioral changes outside the fix:** none at `indent=0`. `NtSecurityDescriptor` now indents its root/footer line at `indent>0` (previously always column 0); this is unobservable at the normal top-level `Describe(0)` call.

### Risk and Rollout
Additive API (two new methods per type); `Describe` behavior is preserved. Safe to merge — no wire-format or default-output changes.