### PR TITLE
Make describe.WithCallback emit bare lines, move newline to the sink (Fixes #127)

### DIFF
--- a/ace/AccessControlEntry.go
+++ b/ace/AccessControlEntry.go
@@ -975,5 +975,5 @@ func (ace *AccessControlEntry) DescribeWithCallback(indent int, printf describe.
 //   - indent (int): The indentation level for formatting the output. Each level increases
 //     the indentation depth, allowing for a hierarchical display of the ACE's components.
 func (ace *AccessControlEntry) Describe(indent int) {
-	ace.DescribeWithCallback(indent, fmt.Printf)
+	ace.DescribeWithCallback(indent, describe.Printfln)
 }

--- a/ace/applicationdata/ApplicationData.go
+++ b/ace/applicationdata/ApplicationData.go
@@ -167,5 +167,5 @@ func (ad *ApplicationData) DescribeWithCallback(indent int, printf describe.Prin
 }
 
 func (ad *ApplicationData) Describe(indent int) {
-	ad.DescribeWithCallback(indent, fmt.Printf)
+	ad.DescribeWithCallback(indent, describe.Printfln)
 }

--- a/ace/header/AccessControlEntryHeader.go
+++ b/ace/header/AccessControlEntryHeader.go
@@ -138,5 +138,5 @@ func (aceheader *AccessControlEntryHeader) DescribeWithCallback(indent int, prin
 }
 
 func (aceheader *AccessControlEntryHeader) Describe(indent int) {
-	aceheader.DescribeWithCallback(indent, fmt.Printf)
+	aceheader.DescribeWithCallback(indent, describe.Printfln)
 }

--- a/ace/mask/AccessControlMask.go
+++ b/ace/mask/AccessControlMask.go
@@ -104,5 +104,5 @@ func (acm *AccessControlMask) DescribeWithCallback(indent int, printf describe.P
 // Describe outputs the AccessControlMask details in a formatted manner.
 // It displays the raw mask value and the associated flags.
 func (acm *AccessControlMask) Describe(indent int) {
-	acm.DescribeWithCallback(indent, fmt.Printf)
+	acm.DescribeWithCallback(indent, describe.Printfln)
 }

--- a/acl/DiscretionaryAccessControlList.go
+++ b/acl/DiscretionaryAccessControlList.go
@@ -119,5 +119,5 @@ func (dacl *DiscretionaryAccessControlList) DescribeWithCallback(indent int, pri
 }
 
 func (dacl *DiscretionaryAccessControlList) Describe(indent int) {
-	dacl.DescribeWithCallback(indent, fmt.Printf)
+	dacl.DescribeWithCallback(indent, describe.Printfln)
 }

--- a/acl/DiscretionaryAccessControlListHeader.go
+++ b/acl/DiscretionaryAccessControlListHeader.go
@@ -118,5 +118,5 @@ func (daclheader *DiscretionaryAccessControlListHeader) DescribeWithCallback(ind
 }
 
 func (daclheader *DiscretionaryAccessControlListHeader) Describe(indent int) {
-	daclheader.DescribeWithCallback(indent, fmt.Printf)
+	daclheader.DescribeWithCallback(indent, describe.Printfln)
 }

--- a/acl/SystemAccessControlList.go
+++ b/acl/SystemAccessControlList.go
@@ -121,5 +121,5 @@ func (sacl *SystemAccessControlList) DescribeWithCallback(indent int, printf des
 }
 
 func (sacl *SystemAccessControlList) Describe(indent int) {
-	sacl.DescribeWithCallback(indent, fmt.Printf)
+	sacl.DescribeWithCallback(indent, describe.Printfln)
 }

--- a/acl/SystemAccessControlListHeader.go
+++ b/acl/SystemAccessControlListHeader.go
@@ -114,5 +114,5 @@ func (saclheader *SystemAccessControlListHeader) DescribeWithCallback(indent int
 }
 
 func (saclheader *SystemAccessControlListHeader) Describe(indent int) {
-	saclheader.DescribeWithCallback(indent, fmt.Printf)
+	saclheader.DescribeWithCallback(indent, describe.Printfln)
 }

--- a/describe.md
+++ b/describe.md
@@ -1,0 +1,240 @@
+---
+name: describe-pattern
+description: >-
+  Implement or refactor a Go structure's human-readable tree output using the
+  three-layer Describe pattern: DescribeList() []string (content), 
+  DescribeWithCallback(indent, printf) (rendering + sink), and Describe(indent)
+  (stdout convenience). Use whenever adding a Describe method to a new struct,
+  converting an existing Describe(indent int) that prints directly with
+  fmt.Printf/strings.Repeat, making describe output capturable/redirectable, or
+  keeping a project's Describe methods consistent. Triggers: "add a Describe
+  method", "refactor Describe", "DescribeList", "make the tree output
+  capturable", "describe pattern".
+---
+
+# Describe pattern
+
+Apply this when a Go structure must render itself as an indented,
+human-readable tree **and** expose that content as data (so callers can capture,
+redirect, or compose it). It separates three concerns: **what** the lines are,
+**how deep** they are indented, and **where** they go.
+
+## The contract
+
+Every describable type implements the same trio, with a strict one-way
+dependency:
+
+```
+Describe(indent)  ──calls──▶  DescribeWithCallback(indent, describe.Printfln)  ──iterates──▶  DescribeList()
+```
+
+```go
+// 1. Content — the lines at indentation depth 0. Source of truth.
+func (t *T) DescribeList() []string
+
+// 2. Rendering + sink — indent each line and route it to a fmt.Printf-like callback.
+func (t *T) DescribeWithCallback(indent int, printf describe.Printf)
+
+// 3. Convenience — print to stdout. Unchanged public behavior.
+func (t *T) Describe(indent int)
+```
+
+- `DescribeList()` is the **only** place that knows the content.
+- `DescribeWithCallback` is the **only** place that adds indentation. It emits
+  each line **bare** (no trailing newline) and lets the callback decide
+  termination.
+- `Describe` is a one-liner that picks `describe.Printfln` as the sink — a
+  stdout sink that appends the newline.
+
+New output behavior (buffer, logger, `io.Writer`) never touches a type — the
+caller supplies a different callback.
+
+## Step 1 — Ensure the helper package exists
+
+Shared logic lives in one package (e.g. `utils/describe`) so per-type methods
+stay tiny and identical. Create it if absent:
+
+```go
+package describe
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Unit is one level of indentation in the tree output.
+const Unit = " │ "
+
+// Printf is the signature of a fmt.Printf-like sink. fmt.Printf satisfies it
+// directly, as does any wrapper around fmt.Fprintf or a structured logger.
+type Printf = func(format string, a ...any) (int, error)
+
+// Printfln is the default Describe sink: a Printf-compatible callback that
+// writes to stdout and appends a trailing newline. WithCallback emits bare
+// lines, so the sink decides how each line is terminated.
+func Printfln(format string, a ...any) (int, error) {
+	return fmt.Printf(format+"\n", a...)
+}
+
+// Nest prefixes each of the given lines with one indentation Unit. Used to
+// compose a parent's DescribeList from its children's.
+func Nest(lines []string) []string {
+	nested := make([]string, len(lines))
+	for i, line := range lines {
+		nested[i] = Unit + line
+	}
+	return nested
+}
+
+// WithCallback renders lines at the given depth: it prepends indent copies of
+// Unit to each line and routes the result to printf. Lines are emitted bare,
+// without a trailing newline; the callback decides termination.
+func WithCallback(indent int, lines []string, printf Printf) {
+	prefix := strings.Repeat(Unit, indent)
+	for _, line := range lines {
+		printf("%s%s", prefix, line)
+	}
+}
+```
+
+Hold these invariants:
+
+- **`Unit` is the single source of indentation.** Never hand-write `" │ "`
+  prefixes except for a line intrinsically one level deeper than its siblings.
+- **`DescribeList()` lines carry no outer indentation** — always depth 0.
+  Indentation is applied exactly once, at render time, by `WithCallback`.
+- **`WithCallback` emits bare lines** (no trailing newline). Termination is the
+  sink's job: `Describe` uses `Printfln` for stdout; a buffer/logger sink adds
+  whatever terminator it wants.
+- **Pass line text as an argument**, never as the format string
+  (`printf("%s%s", prefix, line)`), so a `%` inside a line is never interpreted.
+
+## Step 2 — Write `DescribeList` for the type
+
+Pick the recipe matching the shape.
+
+### Leaf type
+
+Opening tag, one `fmt.Sprintf` per field line (each starting with `" │ "`),
+closing `" └─"`:
+
+```go
+func (m *AccessControlMask) DescribeList() []string {
+	return []string{
+		"<AccessControlMask>",
+		fmt.Sprintf(" │ \x1b[93mMask\x1b[0m : \x1b[96m0x%08x\x1b[0m (\x1b[94m%s\x1b[0m)", m.RawValue, m.String()),
+		" └─",
+	}
+}
+```
+
+### Composite type
+
+Splice in each child's `DescribeList()` one level deeper via `describe.Nest`:
+
+```go
+func (sacl *SystemAccessControlList) DescribeList() []string {
+	lines := []string{"<SystemAccessControlList>"}
+	lines = append(lines, describe.Nest(sacl.Header.DescribeList())...)
+	for _, ace := range sacl.Entries {
+		lines = append(lines, describe.Nest(ace.DescribeList())...)
+	}
+	lines = append(lines, " └─")
+	return lines
+}
+```
+
+### Child two levels deep (wrapper subtree)
+
+Build the wrapper as its own list, then `Nest` the whole thing once:
+
+```go
+if ntsd.Owner != nil {
+	owner := []string{"<Owner>"}
+	owner = append(owner, describe.Nest(ntsd.Owner.DescribeList())...) // SID one level under <Owner>
+	owner = append(owner, " └─")
+	lines = append(lines, describe.Nest(owner)...)                     // whole block one level under root
+}
+```
+
+### Single line one level deeper than its siblings
+
+Prefix that one line with `describe.Unit` directly:
+
+```go
+lines = append(lines, fmt.Sprintf(" │ \x1b[93mSubAuthorities (%03d)\x1b[0m :", sid.SubAuthorityCount))
+for index, sub := range sid.SubAuthorities {
+	lines = append(lines, describe.Unit+fmt.Sprintf(" │ \x1b[93mSubAuthority %02d\x1b[0m   : \x1b[96m0x%08x\x1b[0m (\x1b[94m%d\x1b[0m)", index, sub, sub))
+}
+lines = append(lines, describe.Unit+" └─")
+```
+
+### Conditionals and loops
+
+`DescribeList` is ordinary Go. Branch and loop freely; `append` lines (and
+`Nest`ed child lists) instead of printing.
+
+## Step 3 — Add the two boilerplate methods
+
+Identical for every type:
+
+```go
+func (t *T) DescribeWithCallback(indent int, printf describe.Printf) {
+	describe.WithCallback(indent, t.DescribeList(), printf)
+}
+
+func (t *T) Describe(indent int) {
+	t.DescribeWithCallback(indent, describe.Printfln)
+}
+```
+
+## Converting an existing `Describe`
+
+For a `Describe(indent int)` that used `indentPrompt := strings.Repeat(" │ ", indent)`:
+
+| Old (inside `Describe`)                                   | New (inside `DescribeList`)                              |
+|-----------------------------------------------------------|----------------------------------------------------------|
+| `fmt.Printf("%s…\n", indentPrompt, args…)`                | `append(lines, fmt.Sprintf("…", args…))`                 |
+| line built with `strings.Repeat(" │ ", indent+1)`         | `append(lines, describe.Unit + fmt.Sprintf("…", …))`     |
+| `child.Describe(indent + 1)`                              | `append(lines, describe.Nest(child.DescribeList())...)`  |
+| `child.Describe(indent + 2)`                              | nest twice, or build the wrapper subtree and `Nest` once |
+| a static line (no format args)                            | append a plain string literal (avoid `Sprintf` with no verbs) |
+
+After converting, remove the now-unused `strings` import if nothing else uses it,
+and add the `describe` import.
+
+## Conventions
+
+- **Tag line:** `"<TypeName>"` opens a block; `" └─"` closes it — both are
+  content lines, not rendering artifacts.
+- **Field line:** `" │ "` + label + value, keeping ANSI color escapes
+  (`\x1b[93m…\x1b[0m`) as part of the string. Colors are content; stripping them
+  is a sink-side concern.
+- **Keep `DescribeList` read-only** on the receiver where possible (propagating a
+  known type tag into a child before describing it is acceptable).
+
+## Verify
+
+Output must be **byte-identical** at the top-level call. The identity to assert:
+
+```
+Describe(0) output  ==  strings.Join(DescribeList(), "\n") + "\n"
+```
+
+and, for any indent, every emitted line begins with
+`strings.Repeat(describe.Unit, indent)`.
+
+> A type whose old `Describe` printed its root at column 0 regardless of `indent`
+> becomes uniform here — the root is indented like everything else, observable
+> only at `indent > 0`, never at `Describe(0)`.
+
+Cover with tests (a representative leaf and composite is enough):
+
+1. `Describe(0)` equals `strings.Join(DescribeList(), "\n") + "\n"`.
+2. `DescribeWithCallback(0, sink)` delivers the same lines as `DescribeList()`.
+3. At `indent = n > 0`, every line is prefixed with `strings.Repeat(describe.Unit, n)`.
+4. Helper units: `Nest` prefixes exactly one `Unit` and does not mutate its
+   input; `WithCallback` prepends the right prefix and emits **no** trailing
+   newline (the sink adds it — `Printfln` for stdout).
+
+Then run `go build ./...`, `go vet ./...`, `gofmt -l`, and `go test ./...`.

--- a/identity/Identity.go
+++ b/identity/Identity.go
@@ -89,5 +89,5 @@ func (identity *Identity) DescribeWithCallback(indent int, printf describe.Print
 }
 
 func (identity *Identity) Describe(indent int) {
-	identity.DescribeWithCallback(indent, fmt.Printf)
+	identity.DescribeWithCallback(indent, describe.Printfln)
 }

--- a/object/AccessControlObjectType.go
+++ b/object/AccessControlObjectType.go
@@ -145,5 +145,5 @@ func (aco *AccessControlObjectType) DescribeWithCallback(indent int, printf desc
 }
 
 func (aco *AccessControlObjectType) Describe(indent int) {
-	aco.DescribeWithCallback(indent, fmt.Printf)
+	aco.DescribeWithCallback(indent, describe.Printfln)
 }

--- a/object/InheritedObjectType.go
+++ b/object/InheritedObjectType.go
@@ -77,5 +77,5 @@ func (inheritedObjType *InheritedObjectType) DescribeWithCallback(indent int, pr
 }
 
 func (inheritedObjType *InheritedObjectType) Describe(indent int) {
-	inheritedObjType.DescribeWithCallback(indent, fmt.Printf)
+	inheritedObjType.DescribeWithCallback(indent, describe.Printfln)
 }

--- a/object/ObjectType.go
+++ b/object/ObjectType.go
@@ -72,5 +72,5 @@ func (objType *ObjectType) DescribeWithCallback(indent int, printf describe.Prin
 }
 
 func (objType *ObjectType) Describe(indent int) {
-	objType.DescribeWithCallback(indent, fmt.Printf)
+	objType.DescribeWithCallback(indent, describe.Printfln)
 }

--- a/securitydescriptor/NtSecurityDescriptor.go
+++ b/securitydescriptor/NtSecurityDescriptor.go
@@ -301,5 +301,5 @@ func (ntsd *NtSecurityDescriptor) DescribeWithCallback(indent int, printf descri
 // Parameters:
 //   - indent (int): The indentation level for the output.
 func (ntsd *NtSecurityDescriptor) Describe(indent int) {
-	ntsd.DescribeWithCallback(indent, fmt.Printf)
+	ntsd.DescribeWithCallback(indent, describe.Printfln)
 }

--- a/securitydescriptor/header/NtSecurityDescriptorHeader.go
+++ b/securitydescriptor/header/NtSecurityDescriptorHeader.go
@@ -146,5 +146,5 @@ func (ntsd *NtSecurityDescriptorHeader) DescribeWithCallback(indent int, printf 
 }
 
 func (ntsd *NtSecurityDescriptorHeader) Describe(indent int) {
-	ntsd.DescribeWithCallback(indent, fmt.Printf)
+	ntsd.DescribeWithCallback(indent, describe.Printfln)
 }

--- a/sid/SecurityIdentifier.go
+++ b/sid/SecurityIdentifier.go
@@ -537,5 +537,5 @@ func (sid *SID) DescribeWithCallback(indent int, printf describe.Printf) {
 }
 
 func (sid *SID) Describe(indent int) {
-	sid.DescribeWithCallback(indent, fmt.Printf)
+	sid.DescribeWithCallback(indent, describe.Printfln)
 }

--- a/utils/describe/describe.go
+++ b/utils/describe/describe.go
@@ -7,15 +7,18 @@
 // the text goes) is layered on top:
 //
 //	DescribeList()                -> []string, the lines at indent 0
-//	DescribeWithCallback(indent,  -> prepends indent levels and routes each line
-//	                     printf)      to a fmt.Printf-like callback
-//	Describe(indent)              -> DescribeWithCallback(indent, fmt.Printf)
+//	DescribeWithCallback(indent,  -> prepends indent levels and routes each bare
+//	                     printf)      line (no terminator) to a fmt.Printf-like callback
+//	Describe(indent)              -> DescribeWithCallback(indent, describe.Printfln)
 //
 // A parent structure composes its own list from its children's by nesting each
 // child's DescribeList() one level deeper with Nest.
 package describe
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
 // Unit is one level of indentation in the Describe tree output.
 const Unit = " │ "
@@ -23,6 +26,14 @@ const Unit = " │ "
 // Printf is the signature of a fmt.Printf-like sink. fmt.Printf satisfies it
 // directly, as does any wrapper around fmt.Fprintf or a structured logger.
 type Printf = func(format string, a ...any) (int, error)
+
+// Printfln is the default Describe sink: a Printf-compatible callback that
+// writes to stdout and appends a trailing newline. WithCallback emits bare
+// lines (no terminator), so the sink decides how each line is terminated;
+// Printfln is what Describe uses to reproduce the one-line-per-entry output.
+func Printfln(format string, a ...any) (int, error) {
+	return fmt.Printf(format+"\n", a...)
+}
 
 // Nest prefixes each of the given lines with one indentation Unit. It is used to
 // compose a parent's DescribeList from its children's DescribeList output.
@@ -35,11 +46,12 @@ func Nest(lines []string) []string {
 }
 
 // WithCallback renders lines at the given indentation depth: it prepends indent
-// copies of Unit to each line and routes the result (with a trailing newline) to
-// printf.
+// copies of Unit to each line and routes the result to printf. Lines are emitted
+// bare, without a trailing newline; the callback decides how (and whether) each
+// line is terminated. Describe passes Printfln to add the newline for stdout.
 func WithCallback(indent int, lines []string, printf Printf) {
 	prefix := strings.Repeat(Unit, indent)
 	for _, line := range lines {
-		printf("%s%s\n", prefix, line)
+		printf("%s%s", prefix, line)
 	}
 }


### PR DESCRIPTION
### Linked Issue
`Closes #127`

### Root Cause
`describe.WithCallback` appended a trailing newline to every line (`printf("%s%s\n", ...)`). Line termination is a sink concern, but the renderer owned it, so any custom `Printf` sink passed through `DescribeWithCallback` was forced to receive newline-terminated lines and could not join, buffer, or re-terminate them differently.

### Fix Description
`WithCallback` now emits each indented line bare — `printf("%s%s", prefix, line)` — leaving termination to the callback. To preserve `Describe`'s stdout behavior, add `describe.Printfln`, a `Printf`-compatible sink that writes to stdout and appends the newline, and repoint every type's `Describe` from `fmt.Printf` to `describe.Printfln`.

The newline simply moved from the renderer to the default sink, so `Describe` output is unchanged; callers using `DescribeWithCallback` directly now control termination (e.g. `fmt.Fprintf(&buf, f+"\n", a...)` to collect into a buffer, or omit `\n` to join their own way).

The `describe.md` skill document is updated to describe the bare-line contract, the new `Printfln` sink, and the adjusted testing checklist.

### How Verified
- `go build ./...`, `go vet ./...`, `gofmt -l` — all clean.
- `go test ./...` — all packages pass.
- `TestDescribeLayeringConsistency` confirms `Describe(0)` output is byte-identical: `strings.Join(DescribeList(), "\n") + "\n"`. Existing describe/SDDL/round-trip suites pass unchanged.

### Test Coverage
**Existing:** `utils/describe` helper tests and `securitydescriptor` describe-consistency/indent tests already exercise the changed path; both `WithCallback` (now bare) and `Describe` (now via `Printfln`) are covered, and the layering identity test guards against regressions.

### Scope of Change
- **Files changed:** `utils/describe/describe.go` (WithCallback + new Printfln), the 15 structure files (each `Describe` repointed to `describe.Printfln`), and `describe.md` (skill doc; newly tracked).
- **Submodule pointer updated:** no
- **Behavioral changes outside the fix:** none. `Describe` stdout output is byte-identical.

### Risk and Rollout
Behavioral change is limited to direct callers of `DescribeWithCallback` with a custom sink: they now receive un-terminated lines. `Describe` (the common entry point) is unchanged. Safe to merge.

### Notes
`describe.md` is a design/skill document that was created after the previous PRs and is committed here for the first time so it stays in sync with the implementation.