### PR TITLE
[bug] Fix case-sensitive matching of SDDL keyword operators in conditional expressions (Fixes #131)

### DIFF
--- a/ace/condition/condition.go
+++ b/ace/condition/condition.go
@@ -20,6 +20,7 @@ package condition
 
 import (
 	"fmt"
+	"strings"
 )
 
 // ACE_CONDITION_SIGNATURE marks a callback ACE's ApplicationData as a
@@ -92,7 +93,14 @@ const (
 	signNone     byte = 0x03
 )
 
-// wordOperators maps the SDDL keyword operators to their token byte-codes.
+// wordOperators maps the SDDL keyword operators to their token byte-codes, in the
+// capitalisation used by the MS-DTYP 2.4.4.17.6 and 2.4.4.17.7 tables.
+//
+// Look operators up with lookupWordOperator rather than indexing this map
+// directly: SDDL keyword operators are not case-sensitive, and more than one
+// capitalisation is in circulation. MS-DTYP spells the four "any" operators
+// Member_of_Any, while the operator-name tables in Windows' own sechost.dll and
+// advapi32.dll spell them Member_of_any.
 var wordOperators = map[string]byte{
 	"Contains":                 tokenContains,
 	"Not_Contains":             tokenNotContains,
@@ -110,8 +118,26 @@ var wordOperators = map[string]byte{
 	"Not_Exists":               tokenNotExists,
 }
 
+// wordOperatorsFolded is wordOperators re-keyed on the lowercased operator name,
+// so lookups can be case-insensitive without a linear scan.
+var wordOperatorsFolded = func() map[string]byte {
+	folded := make(map[string]byte, len(wordOperators))
+	for name, token := range wordOperators {
+		folded[strings.ToLower(name)] = token
+	}
+	return folded
+}()
+
+// lookupWordOperator resolves an SDDL keyword operator to its token byte-code,
+// ignoring case.
+func lookupWordOperator(name string) (byte, bool) {
+	token, ok := wordOperatorsFolded[strings.ToLower(name)]
+	return token, ok
+}
+
 // operatorNames is the reverse of wordOperators plus the symbolic operators,
-// used when serializing an AST back to SDDL text.
+// used when serializing an AST back to SDDL text. Serialization always emits the
+// MS-DTYP capitalisation.
 var operatorNames = map[byte]string{
 	tokenAnd:                  "&&",
 	tokenOr:                   "||",
@@ -136,6 +162,16 @@ var operatorNames = map[byte]string{
 	tokenNotDeviceMemberOfAny: "Not_Device_Member_of_Any",
 	tokenExists:               "Exists",
 	tokenNotExists:            "Not_Exists",
+}
+
+// isRelationalWordOperator reports whether tok is one of the keyword operators
+// that take a left- and a right-hand side, and so may appear in infix position.
+func isRelationalWordOperator(tok byte) bool {
+	switch tok {
+	case tokenContains, tokenNotContains, tokenAnyOf, tokenNotAnyOf:
+		return true
+	}
+	return false
 }
 
 func isMemberOfOperator(tok byte) bool {

--- a/ace/condition/condition_test.go
+++ b/ace/condition/condition_test.go
@@ -122,3 +122,99 @@ func TestIsConditional(t *testing.T) {
 		t.Error("short data reported as conditional")
 	}
 }
+
+// TestKeywordOperatorsAreCaseInsensitive checks that SDDL keyword operators parse
+// regardless of case, and in particular that both capitalisations in circulation
+// for the four "any" operators are accepted: MS-DTYP 2.4.4.17.6 spells them
+// Member_of_Any, while the operator-name tables in Windows' own sechost.dll and
+// advapi32.dll spell them Member_of_any.
+//
+// Each variant must encode to exactly the same bytes as the canonical spelling.
+func TestKeywordOperatorsAreCaseInsensitive(t *testing.T) {
+	cases := []struct {
+		canonical string
+		variants  []string
+	}{
+		// Unary membership operators.
+		{`(Member_of {SID(BA)})`, []string{
+			`(member_of {SID(BA)})`, `(MEMBER_OF {SID(BA)})`, `(MeMbEr_Of {SID(BA)})`}},
+		{`(Device_Member_of {SID(BA)})`, []string{
+			`(device_member_of {SID(BA)})`, `(DEVICE_MEMBER_OF {SID(BA)})`}},
+		{`(Not_Member_of {SID(BA)})`, []string{`(not_member_of {SID(BA)})`}},
+		{`(Not_Device_Member_of {SID(BA)})`, []string{`(NOT_DEVICE_MEMBER_OF {SID(BA)})`}},
+
+		// The four operators Windows spells with a lowercase "any".
+		{`(Member_of_Any {SID(BA)})`, []string{
+			`(Member_of_any {SID(BA)})`, `(member_of_any {SID(BA)})`}},
+		{`(Device_Member_of_Any {SID(BA)})`, []string{
+			`(Device_Member_of_any {SID(BA)})`}},
+		{`(Not_Member_of_Any {SID(BA)})`, []string{
+			`(Not_Member_of_any {SID(BA)})`}},
+		{`(Not_Device_Member_of_Any {SID(BA)})`, []string{
+			`(Not_Device_Member_of_any {SID(BA)})`}},
+
+		// Unary existence operators.
+		{`(Exists @User.foo)`, []string{`(exists @User.foo)`, `(EXISTS @User.foo)`}},
+		{`(Not_Exists @User.foo)`, []string{`(not_exists @User.foo)`, `(NOT_EXISTS @User.foo)`}},
+
+		// Binary keyword operators, which are matched on the infix path.
+		{`(@User.a Contains 1)`, []string{`(@User.a contains 1)`, `(@User.a CONTAINS 1)`}},
+		{`(@User.a Not_Contains 1)`, []string{`(@User.a not_contains 1)`}},
+		{`(@User.a Any_of {1,2})`, []string{`(@User.a any_of {1,2})`, `(@User.a ANY_OF {1,2})`}},
+		{`(@User.a Not_Any_of {1,2})`, []string{`(@User.a not_any_of {1,2})`}},
+	}
+
+	for _, c := range cases {
+		want, err := condition.Marshal(c.canonical)
+		if err != nil {
+			t.Fatalf("Marshal(%q) error = %v", c.canonical, err)
+		}
+		for _, variant := range c.variants {
+			t.Run(variant, func(t *testing.T) {
+				got, err := condition.Marshal(variant)
+				if err != nil {
+					t.Fatalf("Marshal(%q) error = %v", variant, err)
+				}
+				if hex.EncodeToString(got) != hex.EncodeToString(want) {
+					t.Fatalf("Marshal(%q) = %s, want %s (same as %q)",
+						variant, hex.EncodeToString(got), hex.EncodeToString(want), c.canonical)
+				}
+			})
+		}
+	}
+}
+
+// TestSerializeUsesSpecCapitalization pins the serialization direction: whatever
+// case was parsed, the text form emitted uses the MS-DTYP capitalisation.
+func TestSerializeUsesSpecCapitalization(t *testing.T) {
+	raw, err := condition.Marshal(`(Member_of_any {SID(BA)})`)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	got, err := condition.Unmarshal(raw)
+	if err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if !strings.Contains(got, "Member_of_Any") {
+		t.Fatalf("Unmarshal() = %q, want it to contain %q", got, "Member_of_Any")
+	}
+}
+
+// TestUnaryKeywordOperatorsRejectedInInfixPosition guards the infix path against
+// admitting the unary operators: only Contains/Not_Contains/Any_of/Not_Any_of may
+// appear between a left- and right-hand side.
+func TestUnaryKeywordOperatorsRejectedInInfixPosition(t *testing.T) {
+	bad := []string{
+		`(@User.a Member_of {SID(BA)})`,
+		`(@User.a member_of {SID(BA)})`,
+		`(@User.a Exists @User.b)`,
+		`(@User.a exists @User.b)`,
+	}
+	for _, expr := range bad {
+		t.Run(expr, func(t *testing.T) {
+			if _, err := condition.Marshal(expr); err == nil {
+				t.Fatalf("Marshal(%q) expected an error, got nil", expr)
+			}
+		})
+	}
+}

--- a/ace/condition/parser.go
+++ b/ace/condition/parser.go
@@ -217,7 +217,7 @@ func (p *parser) parseTerm() (Node, error) {
 	}
 
 	if t.kind == tkWord {
-		if op, ok := wordOperators[t.text]; ok {
+		if op, ok := lookupWordOperator(t.text); ok {
 			// Leading keyword operator: Member_of family or Exists/Not_Exists.
 			p.next()
 			if isMemberOfOperator(op) {
@@ -283,15 +283,11 @@ func (p *parser) peekRelationalOperator() (byte, bool) {
 		return 0, false
 	}
 	if t.kind == tkWord {
-		switch t.text {
-		case "Contains":
-			return tokenContains, true
-		case "Not_Contains":
-			return tokenNotContains, true
-		case "Any_of":
-			return tokenAnyOf, true
-		case "Not_Any_of":
-			return tokenNotAnyOf, true
+		// Only the binary keyword operators are valid in infix position; the
+		// Member_of family and Exists/Not_Exists are unary and handled by
+		// parseTerm.
+		if op, ok := lookupWordOperator(t.text); ok && isRelationalWordOperator(op) {
+			return op, true
 		}
 	}
 	return 0, false


### PR DESCRIPTION
### Linked Issue

`Closes #131`

### Root Cause

Keyword operators were resolved by indexing `wordOperators` with the raw lexed token text (`parser.go:220`), and by a literal `switch` on that same text for the infix operators (`parser.go:285`–`296`). The lexer preserves the original case of a `tkWord` token — correctly, since attribute names are case-preserving — so each operator parsed under exactly one capitalisation, the one hardcoded in the map and the switch.

That is not merely a strictness issue, because two capitalisations of the same four tokens are in circulation. MS-DTYP 2.4.4.17.6 spells them `Member_of_Any`, and `wordOperators` followed the specification. The operator-name tables in Windows' own `sechost.dll` and `advapi32.dll` spell them `Member_of_any`, with a lowercase `any`. The parser therefore rejected conditions carrying the spelling Windows itself produces. The failure was also badly reported: an unrecognised word falls through to being parsed as an attribute name, so the error surfaced as `expected ')' to close parenthesized expression` and never named the operator.

### Fix Description

Keyword-operator lookup now goes through `lookupWordOperator`, which matches against `wordOperatorsFolded` — a lowercase-keyed copy of `wordOperators` built once at package initialisation. Both call sites use it.

`wordOperators` is kept as the canonical, specification-cased table and remains the single source of truth; the folded map is derived from it, so adding an operator in one place keeps both directions consistent. Lowercasing the lookup key was chosen over lowercasing in the lexer because the lexer's output doubles as attribute names, which must retain their case.

The infix site needs to admit only the operators that take a left- and a right-hand side. Replacing its `switch` with the shared lookup would have wrongly accepted the unary `Member_of` family and `Exists`/`Not_Exists` in infix position, so the lookup is gated on a new `isRelationalWordOperator` predicate, mirroring the existing `isMemberOfOperator` helper. Behaviour for unary operators in infix position is unchanged, and there is a test pinning that.

Serialization is untouched: `operatorNames` is keyed by token byte and keeps emitting the MS-DTYP capitalisation, so output remains stable and specification-conformant regardless of the case that was parsed.

### How Verified

**Runtime, before the fix** — `ace/condition.Parse` on each casing:

```
Member_of_Any  (MS-DTYP spelling)              accepted
Member_of_any  (Windows' spelling)             REJECTED: expected ')' to close parenthesized expression
member_of                                      REJECTED: expected ')' to close parenthesized expression
MEMBER_OF                                      REJECTED: expected ')' to close parenthesized expression
exists                                         REJECTED: expected ')' to close parenthesized expression
contains                                       REJECTED: expected ')' to close parenthesized expression
ANY_OF                                         REJECTED: expected ')' to close parenthesized expression
```

**Runtime, after the fix** — all of the above parse, and each variant marshals to bytes identical to the canonical spelling.

**Regression check** — with the new tests in place but `condition.go`/`parser.go` reverted to their pre-fix state, `go test ./ace/condition/...` reports 27 failures. With the fix applied the package passes, and `go test ./...` is green across the repository. `gofmt -l ace/` is clean and `go vet ./ace/...` reports nothing.

### Test Coverage

**Added** — in `ace/condition/condition_test.go`:

- `TestKeywordOperatorsAreCaseInsensitive` — every keyword operator across mixed, lower and upper casings, asserting each variant marshals to the same bytes as the canonical spelling. Covers both parse paths and both spellings of the four `any` operators.
- `TestSerializeUsesSpecCapitalization` — parses `Member_of_any` and asserts the re-serialized text contains `Member_of_Any`, pinning that the fix did not leak into the output form.
- `TestUnaryKeywordOperatorsRejectedInInfixPosition` — asserts `Member_of` and `Exists` are still rejected between a left- and right-hand side, in both casings, guarding the `isRelationalWordOperator` gate.

### Scope of Change

- **Files changed:** `ace/condition/condition.go`, `ace/condition/parser.go`, `ace/condition/condition_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none. One consequence internal to the fix is worth flagging for review: keyword operators are now reserved in every casing, so an expression using a keyword as a local attribute name in non-canonical case — `(member_of == 1)`, say — is now an error where it previously parsed as an attribute. The canonical casing was already reserved this way before the change, so this makes the existing behaviour consistent across casings rather than introducing a new rule.

### Risk and Rollout

Confined to the conditional-expression parser; the encoder, decoder and serializer are untouched. The change strictly widens the set of accepted inputs, apart from the keyword-shadowing consequence noted above. Safe to merge without staged rollout.

### Notes

The `Member_of_any` spelling was found by recovering the 24-entry operator table from `sechost.dll` (`.rdata` RVA `0x070300`) and `advapi32.dll` (RVA `0x06f1e0`) on Windows Server 2025; the two tables are byte-identical and both use the lowercase `any` form.

Two further divergences between those tables and MS-DTYP were observed and are deliberately **not** addressed here, to keep this change focused. Each warrants its own issue:

- Token `0xa3`, named `&` with precedence 10, is present in both Windows tables but is not defined anywhere in MS-DTYP. This package has no constant for it, so such an ACE cannot round-trip.
- `@TOKEN.` appears as a fourth attribute prefix alongside the documented `@USER.`, `@DEVICE.` and `@RESOURCE.`, and is currently rejected as an unknown prefix.
