### PR TITLE
Fix SDDL SID alias table missing ten aliases Windows resolves (Fixes #133)

### DIFF
--- a/sddl/sid/sid.go
+++ b/sddl/sid/sid.go
@@ -5,21 +5,28 @@ package sid
 
 var SDDLToSID = map[string]string{
 	// Well-known SIDs
-	"WD": "S-1-1-0",  // Everyone
-	"CO": "S-1-3-0",  // Creator Owner
-	"CG": "S-1-3-1",  // Creator Group
-	"OW": "S-1-3-4",  // Owner Rights
-	"NU": "S-1-5-2",  // Network
-	"IU": "S-1-5-4",  // Interactive
-	"SU": "S-1-5-6",  // Service
-	"AN": "S-1-5-7",  // Anonymous
-	"ED": "S-1-5-9",  // Enterprise Domain Controllers
-	"PS": "S-1-5-10", // Principal Self
-	"AU": "S-1-5-11", // Authenticated Users
-	"RC": "S-1-5-12", // Restricted Code
-	"SY": "S-1-5-18", // Local System
-	"LS": "S-1-5-19", // Local Service
-	"NS": "S-1-5-20", // Network Service
+	"WD": "S-1-1-0",            // Everyone
+	"CO": "S-1-3-0",            // Creator Owner
+	"CG": "S-1-3-1",            // Creator Group
+	"OW": "S-1-3-4",            // Owner Rights
+	"NU": "S-1-5-2",            // Network
+	"IU": "S-1-5-4",            // Interactive
+	"SU": "S-1-5-6",            // Service
+	"AN": "S-1-5-7",            // Anonymous
+	"ED": "S-1-5-9",            // Enterprise Domain Controllers
+	"PS": "S-1-5-10",           // Principal Self
+	"AU": "S-1-5-11",           // Authenticated Users
+	"RC": "S-1-5-12",           // Restricted Code
+	"SY": "S-1-5-18",           // Local System
+	"LS": "S-1-5-19",           // Local Service
+	"NS": "S-1-5-20",           // Network Service
+	"WR": "S-1-5-33",           // Write Restricted Code
+	"UD": "S-1-5-84-0-0-0-0-0", // User Mode Drivers
+
+	// Application-package and asserted-identity authorities
+	"AC": "S-1-15-2-1", // All Application Packages
+	"AS": "S-1-18-1",   // Authentication Authority Asserted Identity
+	"SS": "S-1-18-2",   // Service Asserted Identity
 
 	// BUILTIN groups
 	"BA": "S-1-5-32-544", // BUILTIN\Administrators
@@ -46,6 +53,8 @@ var SDDLToSID = map[string]string{
 	"HA": "S-1-5-32-578", // BUILTIN\Hyper-V Administrators
 	"AA": "S-1-5-32-579", // BUILTIN\Access Control Assistance Operators
 	"RM": "S-1-5-32-580", // BUILTIN\Remote Management Users
+	"HO": "S-1-5-32-584", // BUILTIN\User Mode Hardware Operators
+	"SH": "S-1-5-32-585", // BUILTIN\OpenSSH Users
 
 	// Domain-relative SIDs (using placeholder domain 0-0-0)
 	"LA": "S-1-5-21-0-0-0-500", // Domain Administrator Account
@@ -62,6 +71,9 @@ var SDDLToSID = map[string]string{
 	"RO": "S-1-5-21-0-0-0-498", // Enterprise Read-Only Domain Controllers (SDDL_ENTERPRISE_RO_DCs)
 	"CN": "S-1-5-21-0-0-0-522", // Cloneable Domain Controllers
 	"RS": "S-1-5-21-0-0-0-553", // RAS Servers Group
+	"AP": "S-1-5-21-0-0-0-525", // Protected Users
+	"KA": "S-1-5-21-0-0-0-526", // Key Admins
+	"EK": "S-1-5-21-0-0-0-527", // Enterprise Key Admins (forest root domain)
 
 	// Mandatory integrity levels
 	"LW": "S-1-16-4096",  // Low Integrity Level

--- a/sddl/sid/sid_test.go
+++ b/sddl/sid/sid_test.go
@@ -32,3 +32,69 @@ func TestSDDLAlias_RO(t *testing.T) {
 		t.Errorf("S-1-5-21-0-0-0-521 must not map to \"RO\" (it is the non-aliased Read-Only Domain Controllers group)")
 	}
 }
+
+// msdtypSidTokens is the complete sid-token list from MS-DTYP 2.5.1.1. Every one
+// of these MUST resolve; "AC", "UD" and "WR" were previously absent.
+var msdtypSidTokens = []string{
+	"DA", "DG", "DU", "ED", "DD", "DC", "BA", "BG", "BU", "LA", "LG", "AO", "BO",
+	"PO", "SO", "AU", "PS", "CO", "CG", "SY", "PU", "WD", "RE", "IU", "NU", "SU",
+	"RC", "WR", "AN", "SA", "CA", "RS", "EA", "PA", "RU", "LS", "NS", "RD", "NO",
+	"MU", "LU", "IS", "CY", "OW", "ER", "RO", "CD", "AC", "RA", "ES", "MS", "UD",
+	"HA", "CN", "AA", "RM", "LW", "ME", "MP", "HI", "SI",
+}
+
+// TestSDDLAliases_MSDTYPCoverage checks that every alias in the MS-DTYP
+// sid-token table resolves to a SID.
+func TestSDDLAliases_MSDTYPCoverage(t *testing.T) {
+	for _, alias := range msdtypSidTokens {
+		if got, ok := SDDLToSID[alias]; !ok || got == "" {
+			t.Errorf("SDDLToSID[%q] missing; MS-DTYP 2.5.1.1 defines it as a sid-token", alias)
+		}
+	}
+}
+
+// TestSDDLAliases_WindowsExtras pins the aliases Windows resolves that the
+// MS-DTYP sid-token table does not list. Values were read from the alias table
+// in sechost.dll (Windows Server 2025), .data RVA 0x99f30.
+func TestSDDLAliases_WindowsExtras(t *testing.T) {
+	want := map[string]string{
+		// Documented by MS-DTYP but previously missing here.
+		"AC": "S-1-15-2-1",
+		"UD": "S-1-5-84-0-0-0-0-0",
+		"WR": "S-1-5-33",
+		// Not in the MS-DTYP sid-token table.
+		"AS": "S-1-18-1",
+		"SS": "S-1-18-2",
+		"HO": "S-1-5-32-584",
+		"SH": "S-1-5-32-585",
+		"AP": "S-1-5-21-0-0-0-525",
+		"KA": "S-1-5-21-0-0-0-526",
+		"EK": "S-1-5-21-0-0-0-527",
+	}
+	for alias, wantSID := range want {
+		got, ok := SDDLToSID[alias]
+		if !ok {
+			t.Errorf("SDDLToSID[%q] missing, want %q", alias, wantSID)
+			continue
+		}
+		if got != wantSID {
+			t.Errorf("SDDLToSID[%q] = %q, want %q", alias, got, wantSID)
+		}
+		if back := SIDToSDDL[wantSID]; back != alias {
+			t.Errorf("SIDToSDDL[%q] = %q, want %q", wantSID, back, alias)
+		}
+	}
+}
+
+// TestSDDLAliases_NoDuplicateSIDs guards the derived reverse map: two aliases
+// sharing a SID would make SIDToSDDL depend on map iteration order.
+func TestSDDLAliases_NoDuplicateSIDs(t *testing.T) {
+	seen := make(map[string]string, len(SDDLToSID))
+	for alias, sidStr := range SDDLToSID {
+		if other, dup := seen[sidStr]; dup {
+			t.Errorf("aliases %q and %q both map to %q; SIDToSDDL[%q] is nondeterministic",
+				other, alias, sidStr, sidStr)
+		}
+		seen[sidStr] = alias
+	}
+}


### PR DESCRIPTION
### Linked Issue

`Closes #133`

### Root Cause

`SDDLToSID` was transcribed from the MS-DTYP 2.5.1.1 `sid-token` table and three of its rows were omitted: `AC`, `UD` and `WR`. Because the map is the only alias source for both the ACE trustee path and the `SID(...)` operand path inside a conditional expression, any SDDL string using one of them failed to parse outright. `AC` (`ALL APPLICATION PACKAGES`) is present in the default DACL of many Windows files, registry keys and directory objects, so this affected descriptors collected from real systems rather than only hand-written ones.

Separately, the MS-DTYP table itself is out of date relative to Windows: seven aliases that the OS resolves have no row in it, so a map faithful to the spec is still incomplete against real input.

### Fix Description

Ten entries added to `SDDLToSID`, grouped with the existing comment structure (well-known, BUILTIN, domain-relative), plus a new group for the application-package and asserted-identity authorities.

The three MS-DTYP omissions are straightforward. The seven undocumented values were not guessed: they were read out of the alias table Windows itself walks — `sechost.dll` (Windows Server 2025), `.data` RVA `0x99f30`, 67 entries of stride `0x68`, with the alias at record `+0x02`, the RID at `+0x18` and a SID-prefix template selector at `+0x1c`. Before trusting that decode on the unknown aliases it was validated against 19 aliases whose SIDs are independently known (`WD`, `SY`, `BA`, `AC`, `AU`, `AN`, `IU`, `LS`, `NS`, `CO`, `CG`, `OW`, `HI`, `ME`, `SI`, `LW`, `DA`, `SA`, `EA`), with zero mismatches.

Domain-relative additions follow the placeholder-domain convention already used in this map (`S-1-5-21-0-0-0-<rid>`) rather than introducing a second representation.

One deliberate non-change: on Windows, `EK` resolves against the **forest root** domain, not the local domain (its table entry uses a different template selector, the same one as `SA`, `EA` and `RO`). That distinction cannot be represented while the domain portion is a placeholder, so it is recorded in a comment instead of encoded. It matters for any future change that resolves a real domain SID, because expanding a forest-root alias against the local domain yields a different, valid-looking principal instead of an error — a wrong answer rather than a failure.

### How Verified

**Runtime, before the fix** — each alias inside a conditional expression:

```
SID(AC) ... REJECT  unknown SID "AC" in conditional expression
SID(UD) ... REJECT  unknown SID "UD" in conditional expression
SID(WR) ... REJECT  unknown SID "WR" in conditional expression
SID(AP), SID(KA), SID(EK), SID(AS), SID(SS), SID(HO), SID(SH)  — all REJECT
```

**Runtime, after the fix** — all ten resolve, in both operand and trustee position:

```
SID(AC)  accept -> (Member_of {SID(S-1-15-2-1)})
SID(UD)  accept -> (Member_of {SID(S-1-5-84-0-0-0-0-0)})
SID(WR)  accept -> (Member_of {SID(S-1-5-33)})
SID(AS)  accept -> (Member_of {SID(S-1-18-1)})
SID(HO)  accept -> (Member_of {SID(S-1-5-32-584)})
...
trustee  accept -> D:P(A;;FA;;;AC)(A;;FA;;;HO)
```

The trustee line also shows the derived reverse map resolving the new SIDs back to their aliases.

**Repository suite** — `go test ./...` green; `gofmt -l` clean on both changed files; `go vet` reports nothing.

### Test Coverage

**Added** — in `sddl/sid/sid_test.go`:

- `TestSDDLAliases_MSDTYPCoverage` — asserts every one of the 61 `sid-token` entries from MS-DTYP 2.5.1.1 resolves. This is the regression guard for the actual bug and fails on `AC`, `UD`, `WR` without the fix.
- `TestSDDLAliases_WindowsExtras` — pins all ten added aliases to their exact SIDs and checks the reverse mapping round-trips.
- `TestSDDLAliases_NoDuplicateSIDs` — guards the derived `SIDToSDDL`: two aliases sharing a SID string would make the reverse map depend on Go map iteration order. It passes today and prevents a future addition from silently introducing that nondeterminism.

### Scope of Change

- **Files changed:** `sddl/sid/sid.go`, `sddl/sid/sid_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** none. Purely additive to a lookup table; no existing entry was altered and no code path changed.

### Risk and Rollout

Additive only — the change can make previously failing input parse, and cannot change the result of input that already parsed. Safe to merge without staged rollout.

### Notes

`sddl/sddl_functions_test.go` is flagged by `gofmt -l` on `main` already; it is untouched here to keep the diff to the fix.

Two properties of the Windows alias table found while sourcing these values are recorded in #133 and not acted on here: `CY` is duplicated in that table (two identical entries), and `CN` is absent from the 67-entry table, appearing only in a separate 15-entry domain-RID table at RVA `0x99910`. `CN` is already present and correct in this map.

Filed alongside this from the same investigation: #134 (SDDL ACE types `TL`/`FL` unusable) and #135 (the two undocumented conditional-expression tokens `0xfc`/`@TOKEN.` and `0xa3`/`&`).
