### PR TITLE
Add support for the undocumented bitwise-AND operator & (0xa3) (Part of #135)

### DIFF
--- a/ace/condition/condition.go
+++ b/ace/condition/condition.go
@@ -84,6 +84,27 @@ const (
 	// Binary logical operators.
 	tokenAnd byte = 0xa0
 	tokenOr  byte = 0xa1
+
+	// tokenBitwiseAnd is an operator that Windows implements but MS-DTYP does not
+	// document: neither the relational table (2.4.4.17.6, which stops at 0x93) nor
+	// the logical table (2.4.4.17.7, which defines only 0xa0/0xa1/0xa2) lists it,
+	// and the 2.5.1.1 ABNF has "&&" but never a lone "&".
+	//
+	// It is a bitwise AND of two 64-bit integer operands, evaluating TRUE when the
+	// result is non-zero, so it reads as a flag test: (@Resource.flags & 4).
+	//
+	// It is parsed here as a binary relational operator, because that is what its
+	// operands are: a value-bearing left side and a literal or attribute on the
+	// right, the same shape as ==. Note one deliberate divergence from Windows in
+	// the text grammar: Windows' operator table gives '&' precedence 10, the lowest
+	// of all the binary operators (|| is 11, && is 12), so Windows groups
+	// "a & b || c" as "a & (b || c)". This package groups it as "(a & b) || c",
+	// like every other relational operator. The Windows grouping is ill-typed by
+	// '&'s own operand rules - the right side would be a logical result rather than
+	// an integer - so it cannot evaluate to TRUE, and no meaningful descriptor
+	// depends on it. Parenthesize explicitly if the exact Windows tree is required;
+	// the binary form round-trips either tree faithfully.
+	tokenBitwiseAnd byte = 0xa3
 )
 
 // Base codes for integer literals (MS-DTYP 2.4.4.17.5).
@@ -148,6 +169,7 @@ func lookupWordOperator(name string) (byte, bool) {
 var operatorNames = map[byte]string{
 	tokenAnd:                  "&&",
 	tokenOr:                   "||",
+	tokenBitwiseAnd:           "&",
 	tokenNot:                  "!",
 	tokenEqual:                "==",
 	tokenNotEqual:             "!=",

--- a/ace/condition/condition_test.go
+++ b/ace/condition/condition_test.go
@@ -349,3 +349,140 @@ func TestTokenAttribute_NotAliasOfUserAttr(t *testing.T) {
 		t.Fatalf("@User. round-trip = %q, want %q", text, `@User.foo == 1`)
 	}
 }
+
+// TestBitwiseAnd_0xa3 covers the undocumented '&' operator, token 0xa3. Neither
+// MS-DTYP's relational table (2.4.4.17.6, which stops at 0x93) nor its logical
+// table (2.4.4.17.7, which defines only 0xa0/0xa1/0xa2) lists it, and the 2.5.1.1
+// ABNF has "&&" but never a lone "&". Windows implements it in all three copies of
+// the operator table (sechost.dll, advapi32.dll, ntoskrnl.exe) and the kernel
+// evaluator computes a bitwise AND of two 64-bit integers, TRUE when non-zero.
+func TestBitwiseAnd_0xa3(t *testing.T) {
+	raw, err := condition.Marshal(`(@User.flags & 4)`)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	// Postfix: the operator is the last non-padding byte.
+	end := len(raw)
+	for end > 0 && raw[end-1] == 0x00 {
+		end--
+	}
+	if end == 0 || raw[end-1] != 0xa3 {
+		t.Fatalf("trailing operator byte = 0x%02x, want 0xa3 (encoded: %s)",
+			raw[end-1], hex.EncodeToString(raw))
+	}
+	got, err := condition.Unmarshal(raw)
+	if err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if got != `@User.flags & 4` {
+		t.Fatalf("Unmarshal() = %q, want %q", got, `@User.flags & 4`)
+	}
+}
+
+// TestBitwiseAnd_FlagTestForms exercises the operand shapes '&' actually takes: a
+// value-bearing left side with a literal or attribute on the right. These are the
+// forms a flag test uses, and the reason '&' is parsed as a binary relational
+// operator rather than alongside && and ||.
+func TestBitwiseAnd_FlagTestForms(t *testing.T) {
+	for _, expr := range []string{
+		`(@User.a & 1)`,
+		`(@Resource.flags & 4)`,
+		`(@User.flags & 0x10)`,
+		`(@User.a & @User.b)`,
+		`(flags & 3)`,
+		// Both undocumented constructs in one expression: the 0xfc attribute
+		// token as the left operand of the 0xa3 operator.
+		`(@Token.flags & 8)`,
+	} {
+		t.Run(expr, func(t *testing.T) {
+			first, err := condition.Marshal(expr)
+			if err != nil {
+				t.Fatalf("Marshal(%q) error = %v", expr, err)
+			}
+			text, err := condition.Unmarshal(first)
+			if err != nil {
+				t.Fatalf("Unmarshal() error = %v", err)
+			}
+			second, err := condition.Marshal("(" + text + ")")
+			if err != nil {
+				t.Fatalf("re-Marshal(%q) error = %v", text, err)
+			}
+			if hex.EncodeToString(first) != hex.EncodeToString(second) {
+				t.Fatalf("round-trip not byte-stable:\n first  = %s\n second = %s",
+					hex.EncodeToString(first), hex.EncodeToString(second))
+			}
+		})
+	}
+}
+
+// TestBitwiseAnd_LogicalOperandRoundTrips is the regression test for the tree
+// Windows' own parser can build but this package's text grammar does not produce.
+// Because '&' has precedence 10 there — below || (11) and && (12) — Windows groups
+// "a & b || c" as "a & (b || c)", giving a '&' whose right operand is a logical
+// expression. The binary form encodes that unambiguously in postfix, so decoding
+// must yield parenthesized text that re-encodes to the identical bytes.
+func TestBitwiseAnd_LogicalOperandRoundTrips(t *testing.T) {
+	// artx | @User.a | @User.b | @User.c | 0xa1 (||) | 0xa3 (&) | pad
+	blob, err := hex.DecodeString(
+		"61727478" +
+			"f902000000" + "6100" +
+			"f902000000" + "6200" +
+			"f902000000" + "6300" +
+			"a1" + "a3" + "00")
+	if err != nil {
+		t.Fatalf("bad test vector: %v", err)
+	}
+	text, err := condition.Unmarshal(blob)
+	if err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	const want = `@User.a & (@User.b || @User.c)`
+	if text != want {
+		t.Fatalf("Unmarshal() = %q, want %q", text, want)
+	}
+	again, err := condition.Marshal("(" + text + ")")
+	if err != nil {
+		t.Fatalf("re-Marshal(%q) error = %v", text, err)
+	}
+	if hex.EncodeToString(again) != hex.EncodeToString(blob) {
+		t.Fatalf("re-encode differs:\n want = %s\n got  = %s",
+			hex.EncodeToString(blob), hex.EncodeToString(again))
+	}
+}
+
+// TestBitwiseAnd_DoesNotShadowLogicalAnd checks the lexer still matches "&&"
+// before a lone "&", so logical AND keeps token 0xa0.
+func TestBitwiseAnd_DoesNotShadowLogicalAnd(t *testing.T) {
+	andRaw, err := condition.Marshal(`(@User.a == 1 && @User.b == 2)`)
+	if err != nil {
+		t.Fatalf("Marshal(&&) error = %v", err)
+	}
+	if got, _ := condition.Unmarshal(andRaw); got != `@User.a == 1 && @User.b == 2` {
+		t.Fatalf("&& round-trip = %q", got)
+	}
+	if !strings.Contains(hex.EncodeToString(andRaw), "a0") {
+		t.Fatalf("logical AND did not encode token 0xa0: %s", hex.EncodeToString(andRaw))
+	}
+	// A lone '&' must not be accepted where a logical operand is required, since
+	// its operands are values.
+	if _, err := condition.Marshal(`(Member_of {SID(BA)} & Member_of {SID(WD)})`); err == nil {
+		t.Fatal("expected an error for '&' applied to Member_of results (not integer operands)")
+	}
+}
+
+// TestBitwiseAnd_ParenthesizedRHSOnlyForBitwiseAnd pins that the widened
+// right-hand-side grammar is scoped to '&' and does not leak to the other
+// relational operators.
+func TestBitwiseAnd_ParenthesizedRHSOnlyForBitwiseAnd(t *testing.T) {
+	if _, err := condition.Marshal(`(@User.a & (@User.b || @User.c))`); err != nil {
+		t.Fatalf("'&' with a parenthesized RHS should parse, got %v", err)
+	}
+	for _, expr := range []string{
+		`(@User.a == (@User.b || @User.c))`,
+		`(@User.a < (@User.b && @User.c))`,
+	} {
+		if _, err := condition.Marshal(expr); err == nil {
+			t.Errorf("%q should not parse: only '&' accepts a parenthesized RHS", expr)
+		}
+	}
+}

--- a/ace/condition/decode.go
+++ b/ace/condition/decode.go
@@ -191,7 +191,7 @@ func isBinaryOperator(tok byte) bool {
 	switch tok {
 	case tokenEqual, tokenNotEqual, tokenLessThan, tokenLessOrEqual, tokenGreaterThan,
 		tokenGreaterOrEqual, tokenContains, tokenAnyOf, tokenNotContains, tokenNotAnyOf,
-		tokenAnd, tokenOr:
+		tokenAnd, tokenOr, tokenBitwiseAnd:
 		return true
 	}
 	return false

--- a/ace/condition/parser.go
+++ b/ace/condition/parser.go
@@ -116,6 +116,10 @@ func lexSymbolOperator(s string) (string, int, error) {
 		return ">", 1, nil
 	case s[0] == '!':
 		return "!", 1, nil
+	case s[0] == '&':
+		// A lone '&' is the undocumented bitwise-AND operator (token 0xa3). The
+		// "&&" case above is matched first, so this cannot shadow logical AND.
+		return "&", 1, nil
 	}
 	return "", 0, fmt.Errorf("invalid operator near %q", s)
 }
@@ -251,7 +255,7 @@ func (p *parser) parseTerm() (Node, error) {
 		return lhs, nil
 	}
 	p.consumeRelationalOperator()
-	rhs, err := p.parseRHS()
+	rhs, err := p.parseRHS(op)
 	if err != nil {
 		return nil, err
 	}
@@ -279,6 +283,11 @@ func (p *parser) peekRelationalOperator() (byte, bool) {
 			return tokenGreaterThan, true
 		case ">=":
 			return tokenGreaterOrEqual, true
+		case "&":
+			// Undocumented bitwise-AND operator (token 0xa3). It takes value
+			// operands like the other binary relational operators, not the
+			// expression operands that && and || take.
+			return tokenBitwiseAnd, true
 		}
 		return 0, false
 	}
@@ -297,10 +306,27 @@ func (p *parser) consumeRelationalOperator() { p.next() }
 
 // parseRHS parses the right-hand side of a binary relational operator: an
 // @Prefixed attribute, a value-array ("{a,b}"), or a single value.
-func (p *parser) parseRHS() (Node, error) {
+func (p *parser) parseRHS(op byte) (Node, error) {
 	t := p.peek()
 	if p.atEnd() {
 		return nil, fmt.Errorf("expected right-hand-side operand")
+	}
+	// Only '&' accepts a parenthesized sub-expression here. Windows' operator table
+	// gives it precedence 10, below || and &&, so Windows' own parser can build a
+	// '&' whose right side is a logical expression; accepting the parenthesized form
+	// is what lets such a tree survive a binary -> text -> binary round-trip. The
+	// other relational operators keep the narrower grammar.
+	if op == tokenBitwiseAnd && p.isSymbol("(") {
+		p.next()
+		node, err := p.parseExpr()
+		if err != nil {
+			return nil, err
+		}
+		if !p.isSymbol(")") {
+			return nil, fmt.Errorf("expected ')' to close parenthesized right-hand side")
+		}
+		p.next()
+		return node, nil
 	}
 	if t.kind == tkWord && strings.HasPrefix(t.text, "@") {
 		return p.parseAttribute()

--- a/ace/condition/serialize.go
+++ b/ace/condition/serialize.go
@@ -100,7 +100,25 @@ func serializeBinary(v *BinaryOp, parentPrec int) string {
 		return left + " " + operatorNames[v.Op] + " " + right
 	}
 	// Relational operator: `LHS op RHS`.
-	return serializeNode(v.Left, 0) + " " + operatorNames[v.Op] + " " + serializeNode(v.Right, 0)
+	return relationalOperandText(v.Left) + " " + operatorNames[v.Op] + " " +
+		relationalOperandText(v.Right)
+}
+
+// relationalOperandText renders an operand of a binary relational operator,
+// parenthesizing a logical sub-expression.
+//
+// The text grammar never produces such a tree - a relational operator's operands
+// are attribute names and literals - but the binary form can encode one, because
+// postfix carries the structure explicitly. Windows' own parser can also build one
+// for '&' (token 0xa3), whose precedence of 10 places it below || and &&, so
+// "a & b || c" groups there as "a & (b || c)". Without the parentheses that tree
+// would serialize to text that re-parses differently, breaking the round-trip.
+func relationalOperandText(n Node) string {
+	text := serializeNode(n, 0)
+	if b, ok := n.(*BinaryOp); ok && (b.Op == tokenAnd || b.Op == tokenOr) {
+		return "(" + text + ")"
+	}
+	return text
 }
 
 func attributeText(a *Attribute) string {


### PR DESCRIPTION
### Linked Issue

`Part of #135`

**Deliberately not a closing keyword.** #135 covers two undocumented tokens. `0xfc` (`@TOKEN.`) is implemented in #138; this PR implements `0xa3` (`&`). Once both land the issue can be closed manually — neither PR alone resolves it. The two are independent and touch different code paths, so they are kept separate rather than combined.

### Root Cause

Windows implements a conditional-expression operator that MS-DTYP does not document: token `0xa3`, spelled `&`. The relational table ([2.4.4.17.6](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/1711ff81-cf13-4870-919d-b91dca7e50de)) stops at `0x93`, the logical table ([2.4.4.17.7](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-dtyp/6e92a8b3-60d8-4cc0-8441-dd6ba6e59e63)) defines only `0xa0`/`0xa1`/`0xa2`, and the 2.5.1.1 ABNF has `&&` but never a lone `&`. This package was written to the specification, so it rejected the token in both directions: the lexer failed with `invalid operator near "&..."` and the decoder with `unknown conditional-expression token 0xa3`.

It is not a stray table entry. `&` is present in **all three** copies of the operator table — `sechost.dll`, `advapi32.dll` and `ntoskrnl.exe`, byte-identical — with its own name string distinct from `&&`, and it is a first-class lexer delimiter in Windows' own tokenizer. The kernel evaluator implements it: `FUN_14068e214` fetches two operand values and, **for token `0xa3` only**, returns their bitwise AND, with the caller treating non-zero as TRUE and zero as FALSE. Full evidence, including the decompiled arm, is in #135.

So `&` is a **bitwise AND flag test**: `(@Resource.flags & 4)` is TRUE exactly when bit 2 is set.

### Fix Description

| File | Change |
|---|---|
| `ace/condition/condition.go` | `tokenBitwiseAnd byte = 0xa3` with the semantics and the precedence divergence documented; `operatorNames` entry `"&"` |
| `ace/condition/parser.go` | lone `&` in `lexSymbolOperator` (after the `&&` case, so it cannot shadow logical AND); `&` added to `peekRelationalOperator`; `parseRHS` takes the operator and accepts a parenthesized sub-expression for `&` only |
| `ace/condition/serialize.go` | relational operands that are logical sub-expressions are parenthesized, via a new `relationalOperandText` helper |
| `ace/condition/decode.go` | `tokenBitwiseAnd` added to `isBinaryOperator` so the postfix walker pops two operands |

`encode.go` needed no change — it emits `BinaryOp` generically.

**The load-bearing design decision: `&` is a binary *relational* operator, not a third logical connective.** My first attempt added it as a new outermost precedence level, faithfully mirroring Windows' precedence of 10. That was wrong, and the tests caught it immediately: `(@User.a & 1)` failed with `expected an attribute name`, because a logical level forces both operands to be full expressions. `&`'s operand specification in the table is the *relational* shape (identical bytes to `==`, `<`, `Contains`) — a value-bearing left side with a literal or attribute on the right. The flag-test form is the entire purpose of the operator, so it has to parse.

**The consequent divergence, and why it is safe.** Windows' precedence 10 is the lowest of all binary operators (`||` is 11, `&&` is 12), so Windows groups `a & b || c` as `a & (b || c)`. This package groups it as `(a & b) || c`, like every other relational operator. That grouping difference only arises for an expression that is **ill-typed by `&`'s own operand rules** — the right side would be a logical result rather than an integer, so it cannot evaluate to TRUE — which is why no meaningful descriptor depends on it. It is documented on the constant, and callers who need the exact Windows tree can parenthesize explicitly.

**Round-trip fidelity is preserved for the Windows tree anyway.** Windows' parser *can* build a `&` whose right operand is a logical expression, and postfix encodes that unambiguously. Two changes make such a blob survive binary → text → binary: the serializer parenthesizes a logical operand of a relational operator, and `parseRHS` accepts a parenthesized right-hand side for `&`. That widened grammar is scoped to `&` — `(@User.a == (@User.b || @User.c))` still does not parse — with a test pinning that it has not leaked.

### How Verified

**Runtime, before the fix:**

```
(@User.flags & 4) from text      REJECT  invalid operator near "& 4)"
0xa3 binary blob                REJECT  unknown conditional-expression token 0xa3
```

**Runtime, after the fix** — flag-test forms, text → binary → text, byte-stable:

```
(@User.a & 1)             -> @User.a & 1              stable=true
(@Resource.flags & 4)     -> @Resource.flags & 4      stable=true
(@User.flags & 0x10)      -> @User.flags & 0x10       stable=true
(@User.a & @User.b)       -> @User.a & @User.b        stable=true
(flags & 3)               -> flags & 3                stable=true
```

**The Windows-grouped tree**, decoded from hand-assembled postfix `a b c || a3`:

```
-> "@User.a & (@User.b || @User.c)"
re-encodes to the identical bytes: true
```

**Full security-descriptor round-trip**, so the operator works inside a real conditional ACE:

```
D:P(XA;;WP;;;WD;(@Resource.flags & 4))          -> identical
D:P(XA;;WP;;;WD;(@User.a & 1 || @User.b == 2))  -> identical
D:P(XD;;WP;;;WD;(@User.flags & 0x10))           -> identical
```

**Regression check** — with the new tests present but the four source files reverted, `go test ./ace/condition/...` reports **9 failing cases**. With the fix, `go test ./...` is green across the repository, `gofmt -l ace/` is clean and `go vet` reports nothing.

### Test Coverage

**Added** — in `ace/condition/condition_test.go`:

- `TestBitwiseAnd_0xa3` — asserts the trailing operator byte is `0xa3` and the text round-trips.
- `TestBitwiseAnd_FlagTestForms` — five operand shapes (literal, hex literal, attribute-to-attribute, unprefixed local attribute), each byte-stable. This is the test that failed under the first, logical-level design.
- `TestBitwiseAnd_LogicalOperandRoundTrips` — decodes the Windows-grouped postfix `a b c || a3`, asserts the parenthesized text, and asserts it re-encodes byte-identically.
- `TestBitwiseAnd_DoesNotShadowLogicalAnd` — `&&` still encodes `0xa0`, and `&` applied to two `Member_of` results (non-integer operands) is rejected.
- `TestBitwiseAnd_ParenthesizedRHSOnlyForBitwiseAnd` — the widened right-hand-side grammar applies to `&` and not to `==` or `<`.

### Scope of Change

- **Files changed:** `ace/condition/condition.go`, `ace/condition/parser.go`, `ace/condition/serialize.go`, `ace/condition/decode.go`, `ace/condition/condition_test.go`
- **Submodule pointer updated:** no
- **Behavioral changes outside the bug fix:** one, and it is required by the fix. `relationalOperandText` parenthesizes a logical sub-expression used as an operand of *any* binary relational operator, not only `&`. Such a tree is unreachable from this package's text grammar and can only arrive by decoding a binary blob, where the old output would have re-parsed into a different tree; the new output round-trips. No expression that previously serialized correctly changes.

### Risk and Rollout

Additive in the parse and decode directions: input that previously errored may now succeed, and no existing token's encoding or text form changes. The one shared code path touched is the relational serializer, whose behaviour changes only for operand trees the text grammar cannot express. Safe to merge without staged rollout.

### Notes

`&` is absent from `aclui.dll`, so it is unreachable through the Windows security GUI — as is `@TOKEN.`. Neither construct has been observed in a real-world descriptor; the case for supporting them is that Windows accepts, stores and evaluates them, so a library that reads descriptors from live systems should not fail on one.

Not addressed here, and noted for completeness:

- **A latent edge case in Windows itself**, read from the decompiled helper and not tested: it signals "not applicable" with `0xffffffffffffffff` and the caller treats `-1` as an error, so a genuine AND of two all-ones operands is indistinguishable from an error and collapses to UNKNOWN. Not replicated, since this package does not evaluate conditions.
- **`0xa3` cannot be satisfied on an AD DS object.** It needs integer operands, and AD supplies none — `@USER.`/`@DEVICE.` claims resolve to UNKNOWN without Dynamic Access Control, and AD silently discards resource-attribute ACEs. Verified live: all four operand combinations denied, with `&&` and `||` controls behaving correctly. This does not affect the codec, but it means the operator is only meaningful on file-system or registry objects.
